### PR TITLE
Expose Offset constructor

### DIFF
--- a/docs/guide/query_scan.md
+++ b/docs/guide/query_scan.md
@@ -368,6 +368,56 @@ This find all tracks in the given album that last longer than 3 minutes, sorted 
     }
     ```
 
+#### Specifying the Offset
+
+=== "Kotlin"
+    
+    ```kotlin
+    private val table: MusicTable
+    
+    fun loadAlbumTracksAfterTrack(albumToken: String, trackToken: String): List<AlbumTrack> {
+      val tracks = mutableListOf<AlbumTrack>()
+      var page: Page<AlbumTrack.Key, AlbumTrack>? = null
+      val offset = Offset(AlbumTrack.Key(trackToken))
+      do {
+        page = table.albumTracks.query(
+          keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
+          pageSize = 10,
+          initialOffset = page?.offset ?: offset
+        )
+        tracks.addAll(page.contents)
+      } while (page?.hasMorePages == true)
+      return tracks.toList()
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    private final MusicTable table;
+
+    public List<AlbumTrack> loadAlbumTracksAfterTrack(String albumToken, String trackToken) {
+      List<AlbumTrack> tracks = new ArrayList<>();
+      Page<AlbumTrack.Key, AlbumTrack> page = null;
+      Offset<AlbumTrack.Key> firstOffset = new Offset<>(new AlbumTrack.Key(albumToken, trackToken));
+  
+      do {
+        page = table.albumTracks().query(
+            // keyCondition.
+            new BeginsWith<>(new AlbumTrack.Key(albumToken)),
+            // config.
+            new QueryConfig.Builder()
+                    .pageSize(10)
+                    .build(),
+            // initialOffset.
+            page != null ? page.getOffset() : firstOffset
+        );
+        tracks.addAll(page.getContents());
+      } while (page.getHasMorePages());
+      return tracks;
+    }
+    ```
+
 ## Scan
 
 A Scan operation in Amazon DynamoDB reads every item in a table or a secondary index.

--- a/samples/guides/src/main/java/app/cash/tempest/guides/java/QueryNScan.java
+++ b/samples/guides/src/main/java/app/cash/tempest/guides/java/QueryNScan.java
@@ -19,6 +19,7 @@ package app.cash.tempest.guides.java;
 import app.cash.tempest.BeginsWith;
 import app.cash.tempest.Between;
 import app.cash.tempest.FilterExpression;
+import app.cash.tempest.Offset;
 import app.cash.tempest.Page;
 import app.cash.tempest.QueryConfig;
 import app.cash.tempest.ScanConfig;
@@ -134,6 +135,28 @@ public class QueryNScan {
               .build(),
           // initialOffset.
           page != null ? page.getOffset() : null
+      );
+      tracks.addAll(page.getContents());
+    } while (page.getHasMorePages());
+    return tracks;
+  }
+
+  // Query - Specified Offset
+  public List<AlbumTrack> loadAlbumTracksAfterTrack(String albumToken, String trackToken) {
+    List<AlbumTrack> tracks = new ArrayList<>();
+    Page<AlbumTrack.Key, AlbumTrack> page = null;
+    Offset<AlbumTrack.Key> firstOffset = new Offset<>(new AlbumTrack.Key(albumToken, trackToken));
+
+    do {
+      page = table.albumTracks().query(
+          // keyCondition.
+          new BeginsWith<>(new AlbumTrack.Key(albumToken)),
+          // config.
+          new QueryConfig.Builder()
+                  .pageSize(10)
+                  .build(),
+          // initialOffset.
+          page != null ? page.getOffset() : firstOffset
       );
       tracks.addAll(page.getContents());
     } while (page.getHasMorePages());

--- a/samples/guides/src/main/kotlin/app/cash/tempest/guides/QueryNScan.kt
+++ b/samples/guides/src/main/kotlin/app/cash/tempest/guides/QueryNScan.kt
@@ -19,6 +19,7 @@ package app.cash.tempest.guides
 import app.cash.tempest.BeginsWith
 import app.cash.tempest.Between
 import app.cash.tempest.FilterExpression
+import app.cash.tempest.Offset
 import app.cash.tempest.Page
 import app.cash.tempest.WorkerId
 import app.cash.tempest.musiclibrary.AlbumTrack
@@ -100,6 +101,22 @@ class QueryNScan(
         keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
         pageSize = 10,
         initialOffset = page?.offset
+      )
+      tracks.addAll(page.contents)
+    } while (page?.hasMorePages == true)
+    return tracks.toList()
+  }
+
+  // Query - Specified Offset
+  fun loadAlbumTracksAfterTrack(albumToken: String, trackToken: String): List<AlbumTrack> {
+    val tracks = mutableListOf<AlbumTrack>()
+    var page: Page<AlbumTrack.Key, AlbumTrack>? = null
+    val offset = Offset(AlbumTrack.Key(trackToken))
+    do {
+      page = table.albumTracks.query(
+        keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
+        pageSize = 10,
+        initialOffset = page?.offset ?: offset
       )
       tracks.addAll(page.contents)
     } while (page?.hasMorePages == true)

--- a/tempest/src/main/kotlin/app/cash/tempest/Paging.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/Paging.kt
@@ -36,6 +36,6 @@ data class Page<K, T> internal constructor(
     get() = offset != null
 }
 
-data class Offset<K> internal constructor(
+data class Offset<K>(
   val key: K
 )


### PR DESCRIPTION
The Offset constructor was changed to be internal in commit
0ca916f4627a8bc89d2b4b4570c634facfdec0a3, which made it impossible to
query with an arbitrary offset in the table.

One use case for this is to allow an external system to page through the
database, without leaking the details of your schema and access
patterns.