### PR TITLE
Remove IllegalStateException wrapping of TransactionCanceledException

### DIFF
--- a/tempest/src/test/kotlin/app/cash/tempest/CodecTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/CodecTest.kt
@@ -20,6 +20,8 @@ import app.cash.tempest.musiclibrary.AlbumTrack
 import app.cash.tempest.musiclibrary.MusicDb
 import app.cash.tempest.musiclibrary.MusicDbTestModule
 import app.cash.tempest.musiclibrary.MusicItem
+import java.time.LocalDate
+import javax.inject.Inject
 import misk.aws.dynamodb.testing.DockerDynamoDb
 import misk.testing.MiskExternalDependency
 import misk.testing.MiskTest
@@ -27,8 +29,6 @@ import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
-import javax.inject.Inject
 
 @MiskTest(startService = true)
 class CodecTest {

--- a/tempest/src/test/kotlin/app/cash/tempest/LogicalDbTransactionTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/LogicalDbTransactionTest.kt
@@ -25,12 +25,12 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.amazonaws.services.dynamodbv2.model.TransactionCanceledException
 import java.time.Duration
 import javax.inject.Inject
+import kotlin.test.assertFailsWith
 import misk.aws.dynamodb.testing.DockerDynamoDb
 import misk.testing.MiskExternalDependency
 import misk.testing.MiskTest
 import misk.testing.MiskTestModule
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.api.Test
 
 @MiskTest(startService = true)
@@ -195,11 +195,9 @@ class LogicalDbTransactionTest {
     // Introduce a race condition.
     musicTable.playlistInfo.save(playlistInfoV2)
 
-    assertThatIllegalStateException()
-      .isThrownBy {
-        musicDb.transactionWrite(writeTransaction)
-      }
-      .withCauseExactlyInstanceOf(TransactionCanceledException::class.java)
+    assertFailsWith<TransactionCanceledException> {
+      musicDb.transactionWrite(writeTransaction)
+    }
   }
 
   @Test
@@ -258,11 +256,9 @@ class LogicalDbTransactionTest {
       )
       .build()
 
-    assertThatIllegalStateException()
-      .isThrownBy {
-        musicDb.transactionWrite(writeTransaction)
-      }
-      .withCauseExactlyInstanceOf(TransactionCanceledException::class.java)
+    assertFailsWith<TransactionCanceledException> {
+      musicDb.transactionWrite(writeTransaction)
+    }
   }
 
   private fun ifPlaylistVersionIs(playlist_version: Long): DynamoDBTransactionWriteExpression {


### PR DESCRIPTION
Wrapping in IllegalStateException leads to upstream callers returning
500s but many of these exceptions are concurrency and Dynamo resource
contention related and should return 503s. Sending the raw
TransactionCanceledException is more transparent and manageable for
upstream callers.