### PR TITLE
Automatically handle reserved words

### DIFF
--- a/samples/musiclibrary/src/main/kotlin/app/cash/tempest/reservedwords/ReservedWordsDb.kt
+++ b/samples/musiclibrary/src/main/kotlin/app/cash/tempest/reservedwords/ReservedWordsDb.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.tempest.reservedwords
+
+import app.cash.tempest.LogicalDb
+
+interface ReservedWordsDb : LogicalDb {
+  val table: ReservedWordsTable
+}

--- a/samples/musiclibrary/src/main/kotlin/app/cash/tempest/reservedwords/ReservedWordsItem.kt
+++ b/samples/musiclibrary/src/main/kotlin/app/cash/tempest/reservedwords/ReservedWordsItem.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.tempest.reservedwords
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBRangeKey
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable
+
+@DynamoDBTable(tableName = "reserved_words")
+class ReservedWordsItem {
+  // All Items.
+  @DynamoDBHashKey
+  var partition_key: String? = null
+  @DynamoDBRangeKey
+  var sort_key: String? = null
+
+  // Reserved words fields.
+  @DynamoDBAttribute
+  var agent: String? = null
+  @DynamoDBAttribute
+  var counter: String? = null
+  @DynamoDBAttribute
+  var tOkEn: String? = null
+}

--- a/samples/musiclibrary/src/main/kotlin/app/cash/tempest/reservedwords/ReservedWordsTable.kt
+++ b/samples/musiclibrary/src/main/kotlin/app/cash/tempest/reservedwords/ReservedWordsTable.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.tempest.reservedwords
+
+import app.cash.tempest.Attribute
+import app.cash.tempest.InlineView
+import app.cash.tempest.LogicalTable
+
+interface ReservedWordsTable : LogicalTable<ReservedWordsItem> {
+  val reservedWords: InlineView<ReservedWordObject.Key, ReservedWordObject>
+}
+
+data class ReservedWordObject(
+  @Attribute(name = "partition_key")
+  val agent: String,
+  val counter: String,
+  val tOkEn: String
+) {
+  @Attribute(prefix = "INFO_")
+  val sort_key: String = ""
+
+  @Transient
+  val key = Key(agent)
+
+  data class Key(
+    val agent: String
+  ) {
+    val sort_key: String = ""
+  }
+}

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDbQueryable.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDbQueryable.kt
@@ -66,7 +66,22 @@ internal class DynamoDbQueryable<K : Any, I : Any>(
     }
     if (specificAttributeNames.isNotEmpty()) {
       query.withSelect(SPECIFIC_ATTRIBUTES)
-      query.projectionExpression = specificAttributeNames.joinToString(", ")
+      val specificAttributeNamesAliased = mutableListOf<String>()
+      val expressionAttributeNames = mutableMapOf<String, String>()
+      for (name in specificAttributeNames) {
+        val upperName = name.toUpperCase()
+        if (reservedWords.contains(upperName)) {
+          val alias = "#$name"
+          specificAttributeNamesAliased.add(alias)
+          expressionAttributeNames[alias] = name
+        } else {
+          specificAttributeNamesAliased.add(name)
+        }
+      }
+      query.projectionExpression = specificAttributeNamesAliased.joinToString(", ")
+      if (expressionAttributeNames.isNotEmpty()) {
+        query.expressionAttributeNames = expressionAttributeNames
+      }
     }
     query.withReturnConsumedCapacity(returnConsumedCapacity)
     if (filterExpression != null) {
@@ -127,5 +142,77 @@ internal class DynamoDbQueryable<K : Any, I : Any>(
     val offsetKeyAttributes = tableModel.unconvert(this)
     val offsetKey = keyCodec.toApp(offsetKeyAttributes)
     return Offset(offsetKey)
+  }
+
+  companion object {
+    private val reservedWords = listOf(
+        "ABORT", "ABSOLUTE", "ACTION", "ADD", "AFTER", "AGENT", "AGGREGATE", "ALL", "ALLOCATE",
+        "ALTER", "ANALYZE", "AND", "ANY", "ARCHIVE", "ARE", "ARRAY", "AS", "ASC", "ASCII",
+        "ASENSITIVE", "ASSERTION", "ASYMMETRIC", "AT", "ATOMIC", "ATTACH", "ATTRIBUTE", "AUTH",
+        "AUTHORIZATION", "AUTHORIZE", "AUTO", "AVG", "BACK", "BACKUP", "BASE", "BATCH", "BEFORE",
+        "BEGIN", "BETWEEN", "BIGINT", "BINARY", "BIT", "BLOB", "BLOCK", "BOOLEAN", "BOTH",
+        "BREADTH", "BUCKET", "BULK", "BY", "BYTE", "CALL", "CALLED", "CALLING", "CAPACITY",
+        "CASCADE", "CASCADED", "CASE", "CAST", "CATALOG", "CHAR", "CHARACTER", "CHECK", "CLASS",
+        "CLOB", "CLOSE", "CLUSTER", "CLUSTERED", "CLUSTERING", "CLUSTERS", "COALESCE", "COLLATE",
+        "COLLATION", "COLLECTION", "COLUMN", "COLUMNS", "COMBINE", "COMMENT", "COMMIT", "COMPACT",
+        "COMPILE", "COMPRESS", "CONDITION", "CONFLICT", "CONNECT", "CONNECTION", "CONSISTENCY",
+        "CONSISTENT", "CONSTRAINT", "CONSTRAINTS", "CONSTRUCTOR", "CONSUMED", "CONTINUE", "CONVERT",
+        "COPY", "CORRESPONDING", "COUNT", "COUNTER", "CREATE", "CROSS", "CUBE", "CURRENT", "CURSOR",
+        "CYCLE", "DATA", "DATABASE", "DATE", "DATETIME", "DAY", "DEALLOCATE", "DEC", "DECIMAL",
+        "DECLARE", "DEFAULT", "DEFERRABLE", "DEFERRED", "DEFINE", "DEFINED", "DEFINITION", "DELETE",
+        "DELIMITED", "DEPTH", "DEREF", "DESC", "DESCRIBE", "DESCRIPTOR", "DETACH", "DETERMINISTIC",
+        "DIAGNOSTICS", "DIRECTORIES", "DISABLE", "DISCONNECT", "DISTINCT", "DISTRIBUTE", "DO",
+        "DOMAIN", "DOUBLE", "DROP", "DUMP", "DURATION", "DYNAMIC", "EACH", "ELEMENT", "ELSE",
+        "ELSEIF", "EMPTY", "ENABLE", "END", "EQUAL", "EQUALS", "ERROR", "ESCAPE", "ESCAPED", "EVAL",
+        "EVALUATE", "EXCEEDED", "EXCEPT", "EXCEPTION", "EXCEPTIONS", "EXCLUSIVE", "EXEC", "EXECUTE",
+        "EXISTS", "EXIT", "EXPLAIN", "EXPLODE", "EXPORT", "EXPRESSION", "EXTENDED", "EXTERNAL",
+        "EXTRACT", "FAIL", "FALSE", "FAMILY", "FETCH", "FIELDS", "FILE", "FILTER", "FILTERING",
+        "FINAL", "FINISH", "FIRST", "FIXED", "FLATTERN", "FLOAT", "FOR", "FORCE", "FOREIGN",
+        "FORMAT", "FORWARD", "FOUND", "FREE", "FROM", "FULL", "FUNCTION", "FUNCTIONS", "GENERAL",
+        "GENERATE", "GET", "GLOB", "GLOBAL", "GO", "GOTO", "GRANT", "GREATER", "GROUP", "GROUPING",
+        "HANDLER", "HASH", "HAVE", "HAVING", "HEAP", "HIDDEN", "HOLD", "HOUR", "IDENTIFIED",
+        "IDENTITY", "IF", "IGNORE", "IMMEDIATE", "IMPORT", "IN", "INCLUDING", "INCLUSIVE",
+        "INCREMENT", "INCREMENTAL", "INDEX", "INDEXED", "INDEXES", "INDICATOR", "INFINITE",
+        "INITIALLY", "INLINE", "INNER", "INNTER", "INOUT", "INPUT", "INSENSITIVE", "INSERT",
+        "INSTEAD", "INT", "INTEGER", "INTERSECT", "INTERVAL", "INTO", "INVALIDATE", "IS",
+        "ISOLATION", "ITEM", "ITEMS", "ITERATE", "JOIN", "KEY", "KEYS", "LAG", "LANGUAGE", "LARGE",
+        "LAST", "LATERAL", "LEAD", "LEADING", "LEAVE", "LEFT", "LENGTH", "LESS", "LEVEL", "LIKE",
+        "LIMIT", "LIMITED", "LINES", "LIST", "LOAD", "LOCAL", "LOCALTIME", "LOCALTIMESTAMP",
+        "LOCATION", "LOCATOR", "LOCK", "LOCKS", "LOG", "LOGED", "LONG", "LOOP", "LOWER", "MAP",
+        "MATCH", "MATERIALIZED", "MAX", "MAXLEN", "MEMBER", "MERGE", "METHOD", "METRICS", "MIN",
+        "MINUS", "MINUTE", "MISSING", "MOD", "MODE", "MODIFIES", "MODIFY", "MODULE", "MONTH",
+        "MULTI", "MULTISET", "NAME", "NAMES", "NATIONAL", "NATURAL", "NCHAR", "NCLOB", "NEW",
+        "NEXT", "NO", "NONE", "NOT", "NULL", "NULLIF", "NUMBER", "NUMERIC", "OBJECT", "OF",
+        "OFFLINE", "OFFSET", "OLD", "ON", "ONLINE", "ONLY", "OPAQUE", "OPEN", "OPERATOR", "OPTION",
+        "OR", "ORDER", "ORDINALITY", "OTHER", "OTHERS", "OUT", "OUTER", "OUTPUT", "OVER",
+        "OVERLAPS", "OVERRIDE", "OWNER", "PAD", "PARALLEL", "PARAMETER", "PARAMETERS", "PARTIAL",
+        "PARTITION", "PARTITIONED", "PARTITIONS", "PATH", "PERCENT", "PERCENTILE", "PERMISSION",
+        "PERMISSIONS", "PIPE", "PIPELINED", "PLAN", "POOL", "POSITION", "PRECISION", "PREPARE",
+        "PRESERVE", "PRIMARY", "PRIOR", "PRIVATE", "PRIVILEGES", "PROCEDURE", "PROCESSED",
+        "PROJECT", "PROJECTION", "PROPERTY", "PROVISIONING", "PUBLIC", "PUT", "QUERY", "QUIT",
+        "QUORUM", "RAISE", "RANDOM", "RANGE", "RANK", "RAW", "READ", "READS", "REAL", "REBUILD",
+        "RECORD", "RECURSIVE", "REDUCE", "REF", "REFERENCE", "REFERENCES", "REFERENCING", "REGEXP",
+        "REGION", "REINDEX", "RELATIVE", "RELEASE", "REMAINDER", "RENAME", "REPEAT", "REPLACE",
+        "REQUEST", "RESET", "RESIGNAL", "RESOURCE", "RESPONSE", "RESTORE", "RESTRICT", "RESULT",
+        "RETURN", "RETURNING", "RETURNS", "REVERSE", "REVOKE", "RIGHT", "ROLE", "ROLES", "ROLLBACK",
+        "ROLLUP", "ROUTINE", "ROW", "ROWS", "RULE", "RULES", "SAMPLE", "SATISFIES", "SAVE",
+        "SAVEPOINT", "SCAN", "SCHEMA", "SCOPE", "SCROLL", "SEARCH", "SECOND", "SECTION", "SEGMENT",
+        "SEGMENTS", "SELECT", "SELF", "SEMI", "SENSITIVE", "SEPARATE", "SEQUENCE", "SERIALIZABLE",
+        "SESSION", "SET", "SETS", "SHARD", "SHARE", "SHARED", "SHORT", "SHOW", "SIGNAL", "SIMILAR",
+        "SIZE", "SKEWED", "SMALLINT", "SNAPSHOT", "SOME", "SOURCE", "SPACE", "SPACES", "SPARSE",
+        "SPECIFIC", "SPECIFICTYPE", "SPLIT", "SQL", "SQLCODE", "SQLERROR", "SQLEXCEPTION",
+        "SQLSTATE", "SQLWARNING", "START", "STATE", "STATIC", "STATUS", "STORAGE", "STORE",
+        "STORED", "STREAM", "STRING", "STRUCT", "STYLE", "SUB", "SUBMULTISET", "SUBPARTITION",
+        "SUBSTRING", "SUBTYPE", "SUM", "SUPER", "SYMMETRIC", "SYNONYM", "SYSTEM", "TABLE",
+        "TABLESAMPLE", "TEMP", "TEMPORARY", "TERMINATED", "TEXT", "THAN", "THEN", "THROUGHPUT",
+        "TIME", "TIMESTAMP", "TIMEZONE", "TINYINT", "TO", "TOKEN", "TOTAL", "TOUCH", "TRAILING",
+        "TRANSACTION", "TRANSFORM", "TRANSLATE", "TRANSLATION", "TREAT", "TRIGGER", "TRIM", "TRUE",
+        "TRUNCATE", "TTL", "TUPLE", "TYPE", "UNDER", "UNDO", "UNION", "UNIQUE", "UNIT", "UNKNOWN",
+        "UNLOGGED", "UNNEST", "UNPROCESSED", "UNSIGNED", "UNTIL", "UPDATE", "UPPER", "URL", "USAGE",
+        "USE", "USER", "USERS", "USING", "UUID", "VACUUM", "VALUE", "VALUED", "VALUES", "VARCHAR",
+        "VARIABLE", "VARIANCE", "VARINT", "VARYING", "VIEW", "VIEWS", "VIRTUAL", "VOID", "WAIT",
+        "WHEN", "WHENEVER", "WHERE", "WHILE", "WINDOW", "WITH", "WITHIN", "WITHOUT", "WORK",
+        "WRAPPED", "WRITE", "YEAR", "ZONE"
+    )
   }
 }

--- a/tempest/src/test/kotlin/app/cash/tempest/DynamoDbQueryableTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/DynamoDbQueryableTest.kt
@@ -28,6 +28,8 @@ import app.cash.tempest.musiclibrary.WHAT_YOU_DO_TO_ME_SINGLE
 import app.cash.tempest.musiclibrary.albumTitles
 import app.cash.tempest.musiclibrary.givenAlbums
 import app.cash.tempest.musiclibrary.trackTitles
+import app.cash.tempest.reservedwords.ReservedWordObject
+import app.cash.tempest.reservedwords.ReservedWordsDb
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import java.time.Duration
 import javax.inject.Inject
@@ -47,8 +49,10 @@ class DynamoDbQueryableTest {
   val dockerDynamoDb = DockerDynamoDb
 
   @Inject lateinit var musicDb: MusicDb
+  @Inject lateinit var reservedWordsDb: ReservedWordsDb
 
   private val musicTable get() = musicDb.music
+  private val reservedWordsTable get() = reservedWordsDb.table
 
   @Test
   fun primaryIndexBetween() {
@@ -282,6 +286,15 @@ class DynamoDbQueryableTest {
     assertThat(page2.albumTitles).containsExactly(
       LOCKDOWN_SINGLE.album_title
     )
+  }
+
+  @Test
+  fun reservedWordsAreAliased() {
+    reservedWordsTable.reservedWords.save(
+        ReservedWordObject("agent", "counter", "tOkEn"))
+
+    // This will throw if we're not correctly handling the reserved words in the object.
+    reservedWordsTable.reservedWords.query(BeginsWith(ReservedWordObject.Key("agent")))
   }
 
   private fun runLengthLongerThan(duration: Duration): FilterExpression {

--- a/tempest/src/test/kotlin/app/cash/tempest/musiclibrary/MusicDbTestModule.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/musiclibrary/MusicDbTestModule.kt
@@ -17,6 +17,8 @@
 package app.cash.tempest.musiclibrary
 
 import app.cash.tempest.LogicalDb
+import app.cash.tempest.reservedwords.ReservedWordsDb
+import app.cash.tempest.reservedwords.ReservedWordsItem
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper
 import com.amazonaws.services.dynamodbv2.model.Projection
@@ -31,18 +33,27 @@ import misk.inject.KAbstractModule
 class MusicDbTestModule : KAbstractModule() {
   override fun configure() {
     install(MiskTestingServiceModule())
-    install(DockerDynamoDbModule(DynamoDbTable(MusicItem::class) {
-      it.apply {
-        for (gsi in globalSecondaryIndexes) {
-          gsi.withProjection(Projection().withProjectionType(ProjectionType.ALL))
-        }
-      }
-    }))
+    install(DockerDynamoDbModule(
+        DynamoDbTable(MusicItem::class) {
+          it.apply {
+            for (gsi in globalSecondaryIndexes) {
+              gsi.withProjection(Projection().withProjectionType(ProjectionType.ALL))
+            }
+          }
+        },
+        DynamoDbTable(ReservedWordsItem::class)))
   }
 
   @Provides
   @Singleton
-  fun provideTestDb(amazonDynamoDB: AmazonDynamoDB): MusicDb {
+  fun provideTestMusicDb(amazonDynamoDB: AmazonDynamoDB): MusicDb {
+    val dynamoDbMapper = DynamoDBMapper(amazonDynamoDB)
+    return LogicalDb(dynamoDbMapper)
+  }
+
+  @Provides
+  @Singleton
+  fun provideTestReservedWordsDb(amazonDynamoDB: AmazonDynamoDB): ReservedWordsDb {
     val dynamoDbMapper = DynamoDBMapper(amazonDynamoDB)
     return LogicalDb(dynamoDbMapper)
   }


### PR DESCRIPTION
This will replace reserved words with specified aliases, and add a mapping from aliases to reserved words as the `expressionAttributeNames` parameter. Mostly wrote this based off of this doc: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html and the `DynamoDBQueryExpression` class.
Still needs to have the rest of the reserved words added if this seems like a reasonable approach.