### PR TITLE
Omit non-key attributes from transaction cancellation exceptions

### DIFF
--- a/tempest/src/main/kotlin/app/cash/tempest/Model.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/Model.kt
@@ -111,10 +111,10 @@ data class TransactionWriteSet(
       item: Any,
       expression: DynamoDBTransactionWriteExpression? = null
     ) = apply {
-      require(!itemsToSave.contains(item) && !itemsToSave.contains(item)) {
-        "Duplicate items are not allowed: $item."
+      val added = itemsToSave.add(item)
+      require(added) {
+        "Duplicate items are not allowed"
       }
-      itemsToSave.add(item)
       if (expression != null) {
         writeExpressions[item] = expression
       }

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDbLogicalDb.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDbLogicalDb.kt
@@ -185,7 +185,7 @@ internal class DynamoDbLogicalDb(
   private fun TransactionWriteSet.describeOperations(): List<String> {
     val descriptions = mutableListOf<String>()
     for (itemToSave in itemsToSave) {
-      descriptions.add("Save $itemToSave")
+      descriptions.add("Save ${itemToSave.encodeAsItem().rawItemKey()}")
     }
     for (keyToDelete in keysToDelete) {
       descriptions.add("Delete $keyToDelete")
@@ -200,5 +200,7 @@ internal class DynamoDbLogicalDb(
     val tableName: String,
     val hashKey: AttributeValue,
     val rangeKey: AttributeValue?
-  )
+  ) {
+    override fun toString() = "$tableName[${hashKey},${rangeKey}]"
+  }
 }

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDbLogicalDb.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDbLogicalDb.kt
@@ -136,11 +136,14 @@ internal class DynamoDbLogicalDb(
   }
 
   fun key(rawItemType: RawItemType, rawItem: Any): RawItemKey {
-    val tableModel = dynamoDbMapper.getTableModel(rawItemType.type.java) as DynamoDBMapperTableModel<Any>
+    val tableModel =
+      dynamoDbMapper.getTableModel(rawItemType.type.java) as DynamoDBMapperTableModel<Any>
     val keyAttributes = tableModel.convert(rawItem)
-    val hashKey = keyAttributes[tableModel.hashKey<Any>().name()]!!
-    val rangeKey = keyAttributes[tableModel.rangeKeyIfExists<Any>()?.name()]
-    return RawItemKey(rawItemType.tableName, hashKey, rangeKey)
+    val hashKey = keyAttributes[rawItemType.hashKeyName]!!
+    val rangeKey = keyAttributes[rawItemType.rangeKeyName]
+    return RawItemKey(
+      rawItemType.tableName, rawItemType.hashKeyName, hashKey, rawItemType.rangeKeyName, rangeKey
+    )
   }
 
   private fun Any.expectedRawItemType(): RawItemType {
@@ -185,22 +188,27 @@ internal class DynamoDbLogicalDb(
   private fun TransactionWriteSet.describeOperations(): List<String> {
     val descriptions = mutableListOf<String>()
     for (itemToSave in itemsToSave) {
-      descriptions.add("Save ${itemToSave.encodeAsItem().rawItemKey()}")
+      val rawItemKey = key(itemToSave.expectedRawItemType(), itemToSave.encodeAsItem())
+      descriptions.add("Save item (non-key attributes omitted) $rawItemKey")
     }
     for (keyToDelete in keysToDelete) {
-      descriptions.add("Delete $keyToDelete")
+      val rawItemKey = key(keyToDelete.expectedRawItemType(), keyToDelete.encodeAsKey())
+      descriptions.add("Delete key $rawItemKey")
     }
     for (keyToCheck in keysToCheck) {
-      descriptions.add("Check $keyToCheck")
+      val rawItemKey = key(keyToCheck.expectedRawItemType(), keyToCheck.encodeAsKey())
+      descriptions.add("Check key $rawItemKey")
     }
     return descriptions.toList()
   }
 
   data class RawItemKey(
     val tableName: String,
-    val hashKey: AttributeValue,
-    val rangeKey: AttributeValue?
+    val hashKeyName: String,
+    val hashKeyValue: AttributeValue,
+    val rangeKeyName: String?,
+    val rangeKeyValue: AttributeValue?
   ) {
-    override fun toString() = "$tableName[${hashKey},${rangeKey}]"
+    override fun toString() = "$tableName[$hashKeyName=$hashKeyValue,$rangeKeyName=$rangeKeyValue]"
   }
 }

--- a/tempest/src/test/kotlin/app/cash/tempest/LogicalDbTransactionTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/LogicalDbTransactionTest.kt
@@ -188,12 +188,16 @@ class LogicalDbTransactionTest {
     // Introduce a race condition.
     musicTable.playlistInfo.save(playlistInfoV2)
 
-    // Confirm the exception message doesn't contain any item data.
     assertThatExceptionOfType(TransactionCanceledException::class.java)
       .isThrownBy {
         musicDb.transactionWrite(writeTransaction)
       }
-      .withMessage("xxxx")
+      // Confirm the exception message doesn't contain any item data.
+      .withMessageContaining(
+        "Write transaction failed: [" +
+          "Save item (non-key attributes omitted) music_items[partition_key={S: PLAYLIST_1,},sort_key={S: INFO_,}], " +
+          "Delete key music_items[partition_key={S: ALBUM_1,},sort_key={S: TRACK_0000000000000001,}]]"
+      )
   }
 
   @Test
@@ -256,6 +260,12 @@ class LogicalDbTransactionTest {
       .isThrownBy {
         musicDb.transactionWrite(writeTransaction)
       }
+      // Confirm the exception message doesn't contain any item data.
+      .withMessageContaining(
+        "Write transaction failed: [" +
+          "Save item (non-key attributes omitted) music_items[partition_key={S: PLAYLIST_1,},sort_key={S: INFO_,}], " +
+          "Check key music_items[partition_key={S: ALBUM_1,},sort_key={S: TRACK_0000000000000001,}]]"
+      )
   }
 
   private fun ifPlaylistVersionIs(playlist_version: Long): DynamoDBTransactionWriteExpression {

--- a/tempest/src/test/kotlin/app/cash/tempest/LogicalDbTransactionTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/LogicalDbTransactionTest.kt
@@ -188,10 +188,12 @@ class LogicalDbTransactionTest {
     // Introduce a race condition.
     musicTable.playlistInfo.save(playlistInfoV2)
 
+    // Confirm the exception message doesn't contain any item data.
     assertThatExceptionOfType(TransactionCanceledException::class.java)
       .isThrownBy {
         musicDb.transactionWrite(writeTransaction)
       }
+      .withMessage("xxxx")
   }
 
   @Test

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
@@ -112,10 +112,10 @@ data class TransactionWriteSet(
       item: Any,
       expression: Expression? = null
     ) = apply {
-      require(!itemsToSave.contains(item) && !itemsToSave.contains(item)) {
-        "Duplicate items are not allowed: $item."
+      val added = itemsToSave.add(item)
+      require(added) {
+        "Duplicate items are not allowed"
       }
-      itemsToSave.add(item)
       if (expression != null) {
         writeExpressions[item] = expression
       }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -234,7 +234,7 @@ internal class DynamoDbLogicalDb(
   private fun TransactionWriteSet.describeOperations(): List<String> {
     val descriptions = mutableListOf<String>()
     for (itemToSave in itemsToSave) {
-      descriptions.add("Save $itemToSave")
+      descriptions.add("Save ${itemToSave.encodeAsItem().rawItemKey()}")
     }
     for (keyToDelete in keysToDelete) {
       descriptions.add("Delete $keyToDelete")
@@ -289,7 +289,9 @@ internal class DynamoDbLogicalDb(
   private data class RawItemKey(
     val tableName: String,
     val key: Key
-  )
+  ) {
+    override fun toString() = "$tableName[${key.partitionKeyValue()},${key.sortKeyValue()}]"
+  }
 
   private data class LoadRequest(
     val key: RawItemKey,

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -17,7 +17,7 @@
 package app.cash.tempest2.internal
 
 import app.cash.tempest.internal.ItemType
-import app.cash.tempest.internal.KeyType
+import app.cash.tempest.internal.RawItemType
 import app.cash.tempest.internal.Schema
 import app.cash.tempest2.BatchWriteSet
 import app.cash.tempest2.ItemSet
@@ -44,6 +44,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.TransactGetItemsEnhancedRe
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.UpdateItemEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.WriteBatch
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException
 import kotlin.reflect.KClass
 
@@ -182,14 +183,25 @@ internal class DynamoDbLogicalDb(
   }
 
   private fun Any.rawItemKey(): RawItemKey {
-    val dynamoDbTable = dynamoDbTable<Any>(this::class)
+    val rawItemType = expectedRawItemType()
     return RawItemKey(
-      dynamoDbTable.tableName(),
+      rawItemType.tableName,
       EnhancedClientUtils.createKeyFromItem(
-        this, dynamoDbTable.tableSchema(),
-        TableMetadata.primaryIndexName()
-      )
+        this,
+        dynamoDbTable<Any>(this::class).tableSchema(),
+        TableMetadata.primaryIndexName(),
+      ),
+      rawItemType.hashKeyName,
+      rawItemType.rangeKeyName,
     )
+  }
+
+  private fun Any.expectedRawItemType(): RawItemType {
+    return requireNotNull(
+      schema.resolveEnclosingRawItemType(
+        this::class
+      )
+    ) { "Cannot find a dynamodb table for ${this::class}" }
   }
 
   private fun <T : Any> dynamoDbTable(tableType: KClass<*>): DynamoDbTable<T> {
@@ -206,14 +218,6 @@ internal class DynamoDbLogicalDb(
         this::class
       )
     ) { "Cannot find an item type for ${this::class}" }
-  }
-
-  private fun Any.expectedKeyType(): KeyType {
-    return requireNotNull(
-      schema.getKey(
-        this::class
-      )
-    ) { "Cannot find an key type for ${this::class}" }
   }
 
   private fun Any.encodeAsKey(): Any {
@@ -234,13 +238,16 @@ internal class DynamoDbLogicalDb(
   private fun TransactionWriteSet.describeOperations(): List<String> {
     val descriptions = mutableListOf<String>()
     for (itemToSave in itemsToSave) {
-      descriptions.add("Save ${itemToSave.encodeAsItem().rawItemKey()}")
+      val rawItemKey = itemToSave.encodeAsItem().rawItemKey()
+      descriptions.add("Save item (non-key attributes omitted) $rawItemKey")
     }
     for (keyToDelete in keysToDelete) {
-      descriptions.add("Delete $keyToDelete")
+      val rawItemKey = keyToDelete.encodeAsKey().rawItemKey()
+      descriptions.add("Delete key $rawItemKey")
     }
     for (keyToCheck in keysToCheck) {
-      descriptions.add("Check $keyToCheck")
+      val rawItemKey = keyToCheck.encodeAsKey().rawItemKey()
+      descriptions.add("Check key $rawItemKey")
     }
     return descriptions.toList()
   }
@@ -288,9 +295,14 @@ internal class DynamoDbLogicalDb(
 
   private data class RawItemKey(
     val tableName: String,
-    val key: Key
+    val key: Key,
+    val hashKeyName: String,
+    val rangeKeyName: String?,
   ) {
-    override fun toString() = "$tableName[${key.partitionKeyValue()},${key.sortKeyValue()}]"
+    val hashKeyValue: AttributeValue get() = key.partitionKeyValue()
+    val rangeKeyValue: AttributeValue? get() = key.sortKeyValue().orElse(null)
+
+    override fun toString() = "$tableName[$hashKeyName=$hashKeyValue,$rangeKeyName=$rangeKeyValue]"
   }
 
   private data class LoadRequest(

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbTransactionTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbTransactionTest.kt
@@ -192,6 +192,7 @@ class LogicalDbTransactionTest {
       .isThrownBy {
         musicDb.transactionWrite(writeTransaction)
       }
+      .withMessage("xxxx")
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbTransactionTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbTransactionTest.kt
@@ -192,7 +192,12 @@ class LogicalDbTransactionTest {
       .isThrownBy {
         musicDb.transactionWrite(writeTransaction)
       }
-      .withMessage("xxxx")
+      // Confirm the exception message doesn't contain any item data.
+      .withMessageContaining(
+        "Write transaction failed: [" +
+          "Save item (non-key attributes omitted) music_items[partition_key=AttributeValue(S=PLAYLIST_1),sort_key=AttributeValue(S=INFO_)], " +
+          "Delete key music_items[partition_key=AttributeValue(S=ALBUM_1),sort_key=AttributeValue(S=TRACK_0000000000000001)]]"
+      )
   }
 
   @Test
@@ -255,6 +260,12 @@ class LogicalDbTransactionTest {
       .isThrownBy {
         musicDb.transactionWrite(writeTransaction)
       }
+      // Confirm the exception message doesn't contain any item data.
+      .withMessageContaining(
+        "Write transaction failed: [" +
+          "Save item (non-key attributes omitted) music_items[partition_key=AttributeValue(S=PLAYLIST_1),sort_key=AttributeValue(S=INFO_)], " +
+          "Check key music_items[partition_key=AttributeValue(S=ALBUM_1),sort_key=AttributeValue(S=TRACK_0000000000000001)]]"
+      )
   }
 
   private fun ifPlaylistVersionIs(playlist_version: Long): Expression {


### PR DESCRIPTION
Instead of printing the full item, which might contain sensitive information, only print the item key. 