### PR TITLE
Support mixed type query and scan

### DIFF
--- a/docs/guide/query_scan.md
+++ b/docs/guide/query_scan.md
@@ -541,6 +541,7 @@ has no sort key prefix. You'd need to explicitly convert this union type to albu
     
       @Attribute(name = "partition_key")
       public final String album_token;
+      @Attribute(noPrefix = true)
       public final String sort_key;
       public final String album_title;
       public final String artist_name;

--- a/samples/guides/src/main/java/app/cash/tempest/guides/java/QueryNScan.java
+++ b/samples/guides/src/main/java/app/cash/tempest/guides/java/QueryNScan.java
@@ -24,6 +24,7 @@ import app.cash.tempest.Page;
 import app.cash.tempest.QueryConfig;
 import app.cash.tempest.ScanConfig;
 import app.cash.tempest.WorkerId;
+import app.cash.tempest.musiclibrary.java.AlbumInfoOrTrack;
 import app.cash.tempest.musiclibrary.java.AlbumTrack;
 import app.cash.tempest.musiclibrary.java.MusicTable;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
@@ -161,6 +162,15 @@ public class QueryNScan {
       tracks.addAll(page.getContents());
     } while (page.getHasMorePages());
     return tracks;
+  }
+
+  // Query - Mixed types
+  public List<AlbumInfoOrTrack> loadAlbumInfoAndTracks(String albumToken) {
+    Page<AlbumInfoOrTrack.Key, AlbumInfoOrTrack> page = table.albumInfoOrTracks().query(
+        // keyCondition.
+        new BeginsWith<>(new AlbumInfoOrTrack.Key(albumToken))
+    );
+    return page.getContents();
   }
 
   // Scan.

--- a/samples/guides/src/main/kotlin/app/cash/tempest/guides/QueryNScan.kt
+++ b/samples/guides/src/main/kotlin/app/cash/tempest/guides/QueryNScan.kt
@@ -22,6 +22,7 @@ import app.cash.tempest.FilterExpression
 import app.cash.tempest.Offset
 import app.cash.tempest.Page
 import app.cash.tempest.WorkerId
+import app.cash.tempest.musiclibrary.AlbumInfoOrTrack
 import app.cash.tempest.musiclibrary.AlbumTrack
 import app.cash.tempest.musiclibrary.MusicTable
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
@@ -96,32 +97,42 @@ class QueryNScan(
   // Query - Pagination.
   fun loadAlbumTracks6(albumToken: String): List<AlbumTrack> {
     val tracks = mutableListOf<AlbumTrack>()
-    var page: Page<AlbumTrack.Key, AlbumTrack>? = null
+    lateinit var page: Page<AlbumTrack.Key, AlbumTrack>
     do {
       page = table.albumTracks.query(
         keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
         pageSize = 10,
-        initialOffset = page?.offset
+        initialOffset = page.offset
       )
       tracks.addAll(page.contents)
-    } while (page?.hasMorePages == true)
+    } while (page.hasMorePages)
     return tracks.toList()
   }
 
   // Query - Specified Offset
   fun loadAlbumTracksAfterTrack(albumToken: String, trackToken: String): List<AlbumTrack> {
     val tracks = mutableListOf<AlbumTrack>()
-    var page: Page<AlbumTrack.Key, AlbumTrack>? = null
+    lateinit var page: Page<AlbumTrack.Key, AlbumTrack>
     val offset = Offset(AlbumTrack.Key(trackToken))
     do {
       page = table.albumTracks.query(
         keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
         pageSize = 10,
-        initialOffset = page?.offset ?: offset
+        initialOffset = page.offset ?: offset
       )
       tracks.addAll(page.contents)
-    } while (page?.hasMorePages == true)
+    } while (page.hasMorePages)
     return tracks.toList()
+  }
+
+  // Query - Mixed types
+  fun loadAlbumInfoAndTracks(albumToken: String): List<AlbumInfoOrTrack> {
+    val page = table.albumInfoOrTracks.query(
+      keyCondition = BeginsWith(
+        prefix = AlbumInfoOrTrack.Key(albumToken)
+      )
+    )
+    return page.contents
   }
 
   // Scan.

--- a/samples/guides2/src/main/java/app/cash/tempest2/guides/java/QueryNScan.java
+++ b/samples/guides2/src/main/java/app/cash/tempest2/guides/java/QueryNScan.java
@@ -21,6 +21,7 @@ import app.cash.tempest2.Between;
 import app.cash.tempest2.Offset;
 import app.cash.tempest2.Page;
 import app.cash.tempest2.QueryConfig;
+import app.cash.tempest2.musiclibrary.java.AlbumInfoOrTrack;
 import app.cash.tempest2.musiclibrary.java.AlbumTrack;
 import app.cash.tempest2.musiclibrary.java.MusicTable;
 import java.time.Duration;
@@ -155,6 +156,15 @@ public class QueryNScan {
       tracks.addAll(page.getContents());
     } while (page.getHasMorePages());
     return tracks;
+  }
+
+  // Query - Mixed types
+  public List<AlbumInfoOrTrack> loadAlbumInfoAndTracks(String albumToken) {
+    Page<AlbumInfoOrTrack.Key, AlbumInfoOrTrack> page = table.albumInfoOrTracks().query(
+        // keyCondition.
+        new BeginsWith<>(new AlbumInfoOrTrack.Key(albumToken))
+    );
+    return page.getContents();
   }
 
   // Scan.

--- a/samples/guides2/src/main/kotlin/app/cash/tempest2/guides/QueryNScan.kt
+++ b/samples/guides2/src/main/kotlin/app/cash/tempest2/guides/QueryNScan.kt
@@ -20,6 +20,7 @@ import app.cash.tempest2.BeginsWith
 import app.cash.tempest2.Between
 import app.cash.tempest2.Offset
 import app.cash.tempest2.Page
+import app.cash.tempest2.musiclibrary.AlbumInfoOrTrack
 import app.cash.tempest2.musiclibrary.AlbumTrack
 import app.cash.tempest2.musiclibrary.MusicTable
 import software.amazon.awssdk.enhanced.dynamodb.Expression
@@ -95,32 +96,42 @@ class QueryNScan(
   // Query - Pagination.
   fun loadAlbumTracks6(albumToken: String): List<AlbumTrack> {
     val tracks = mutableListOf<AlbumTrack>()
-    var page: Page<AlbumTrack.Key, AlbumTrack>? = null
+    lateinit var page: Page<AlbumTrack.Key, AlbumTrack>
     do {
       page = table.albumTracks.query(
         keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
         pageSize = 10,
-        initialOffset = page?.offset
+        initialOffset = page.offset
       )
       tracks.addAll(page.contents)
-    } while (page?.hasMorePages == true)
+    } while (page.hasMorePages)
     return tracks.toList()
   }
 
   // Query - Specified Offset
   fun loadAlbumTracksAfterTrack(albumToken: String, trackToken: String): List<AlbumTrack> {
     val tracks = mutableListOf<AlbumTrack>()
-    var page: Page<AlbumTrack.Key, AlbumTrack>? = null
+    lateinit var page: Page<AlbumTrack.Key, AlbumTrack>
     val offset = Offset(AlbumTrack.Key(trackToken))
     do {
       page = table.albumTracks.query(
         keyCondition = BeginsWith(AlbumTrack.Key(albumToken)),
         pageSize = 10,
-        initialOffset = page?.offset ?: offset
+        initialOffset = page.offset ?: offset
       )
       tracks.addAll(page.contents)
-    } while (page?.hasMorePages == true)
+    } while (page.hasMorePages)
     return tracks.toList()
+  }
+
+  // Query - Mixed types
+  fun loadAlbumInfoAndTracks(albumToken: String): List<AlbumInfoOrTrack> {
+    val page = table.albumInfoOrTracks.query(
+      keyCondition = BeginsWith(
+        prefix = AlbumInfoOrTrack.Key(albumToken)
+      )
+    )
+    return page.contents
   }
 
   // Scan.

--- a/samples/musiclibrary/src/main/java/app/cash/tempest/musiclibrary/java/AlbumInfoOrTrack.java
+++ b/samples/musiclibrary/src/main/java/app/cash/tempest/musiclibrary/java/AlbumInfoOrTrack.java
@@ -8,6 +8,7 @@ public class AlbumInfoOrTrack {
 
   @Attribute(name = "partition_key")
   public final String album_token;
+  @Attribute(noPrefix = true)
   public final String sort_key;
   public final String album_title;
   public final String artist_name;

--- a/samples/musiclibrary/src/main/java/app/cash/tempest/musiclibrary/java/AlbumInfoOrTrack.java
+++ b/samples/musiclibrary/src/main/java/app/cash/tempest/musiclibrary/java/AlbumInfoOrTrack.java
@@ -1,0 +1,62 @@
+package app.cash.tempest.musiclibrary.java;
+
+import app.cash.tempest.Attribute;
+import java.time.Duration;
+import java.time.LocalDate;
+
+public class AlbumInfoOrTrack {
+
+  @Attribute(name = "partition_key")
+  public final String album_token;
+  public final String sort_key;
+  public final String album_title;
+  public final String artist_name;
+  public final LocalDate release_date;
+  public final String genre_name;
+  public final String track_title;
+  public final Duration run_length;
+  public final transient AlbumInfoOrTrack.Key key;
+
+  public AlbumInfoOrTrack(
+      String album_token,
+      String sort_key,
+      String album_title,
+      String artist_name,
+      LocalDate release_date,
+      String genre_name,
+      String track_title,
+      Duration run_length) {
+    this.album_token = album_token;
+    this.sort_key = sort_key;
+    this.album_title = album_title;
+    this.artist_name = artist_name;
+    this.release_date = release_date;
+    this.genre_name = genre_name;
+    this.track_title = track_title;
+    this.run_length = run_length;
+    key = new AlbumInfoOrTrack.Key(album_token);
+  }
+
+  public AlbumInfo albumInfo() {
+    if (sort_key.equals("INFO_")) {
+      return new AlbumInfo(album_token, album_title, artist_name, release_date, genre_name);
+    }
+    return null;
+  }
+
+  public AlbumTrack albumTrack() {
+    if (sort_key.startsWith("TRACK_")) {
+      return new AlbumTrack(album_token, sort_key.substring("TRACK_".length()), track_title, run_length);
+    }
+    return null;
+  }
+
+  public static class Key {
+    public final String album_token;
+    public final String sort_key = "";
+
+    public Key(String album_token) {
+      this.album_token = album_token;
+    }
+  }
+}

--- a/samples/musiclibrary/src/main/java/app/cash/tempest/musiclibrary/java/MusicTable.java
+++ b/samples/musiclibrary/src/main/java/app/cash/tempest/musiclibrary/java/MusicTable.java
@@ -23,6 +23,7 @@ import app.cash.tempest.SecondaryIndex;
 public interface MusicTable extends LogicalTable<MusicItem> {
   InlineView<AlbumInfo.Key, AlbumInfo> albumInfo();
   InlineView<AlbumTrack.Key, AlbumTrack> albumTracks();
+  InlineView<AlbumInfoOrTrack.Key, AlbumInfoOrTrack> albumInfoOrTracks();
 
   InlineView<PlaylistInfo.Key, PlaylistInfo> playlistInfo();
 

--- a/samples/musiclibrary/src/main/kotlin/app/cash/tempest/musiclibrary/MusicTable.kt
+++ b/samples/musiclibrary/src/main/kotlin/app/cash/tempest/musiclibrary/MusicTable.kt
@@ -29,6 +29,7 @@ import kotlin.text.toLong
 interface MusicTable : LogicalTable<MusicItem> {
   val albumInfo: InlineView<AlbumInfo.Key, AlbumInfo>
   val albumTracks: InlineView<AlbumTrack.Key, AlbumTrack>
+  val albumInfoOrTracks: InlineView<AlbumInfoOrTrack.Key, AlbumInfoOrTrack>
 
   val playlistInfo: InlineView<PlaylistInfo.Key, PlaylistInfo>
 
@@ -114,6 +115,42 @@ data class AlbumTrack(
     val track_title: String? = null,
     // To uniquely identify an item in pagination.
     val track_token: String? = null
+  )
+}
+
+data class AlbumInfoOrTrack(
+  @Attribute(name = "partition_key")
+  val album_token: String,
+  @Attribute(noPrefix = true)
+  val sort_key: String,
+  val album_title: String?,
+  val artist_name: String?,
+  val release_date: LocalDate?,
+  val genre_name: String?,
+  val track_title: String?,
+  val run_length: Duration?
+) {
+
+  @Transient
+  val key = Key(album_token, sort_key)
+
+  @Transient
+  val albumInfo: AlbumInfo? = if (sort_key == "INFO_") {
+    AlbumInfo(album_token, album_title!!, artist_name!!, release_date!!, genre_name!!)
+  } else {
+    null
+  }
+
+  @Transient
+  val albumTrack: AlbumTrack? = if (sort_key.startsWith("TRACK_")) {
+    AlbumTrack(album_token, sort_key.removePrefix("TRACK_"), track_title!!, run_length!!)
+  } else {
+    null
+  }
+
+  data class Key(
+    val album_token: String,
+    val sort_key: String = "",
   )
 }
 

--- a/samples/musiclibrary2/src/main/java/app/cash/tempest2/musiclibrary/java/AlbumInfoOrTrack.java
+++ b/samples/musiclibrary2/src/main/java/app/cash/tempest2/musiclibrary/java/AlbumInfoOrTrack.java
@@ -1,0 +1,62 @@
+package app.cash.tempest2.musiclibrary.java;
+
+import app.cash.tempest2.Attribute;
+import java.time.Duration;
+import java.time.LocalDate;
+
+public class AlbumInfoOrTrack {
+
+  @Attribute(name = "partition_key")
+  public final String album_token;
+  public final String sort_key;
+  public final String album_title;
+  public final String artist_name;
+  public final LocalDate release_date;
+  public final String genre_name;
+  public final String track_title;
+  public final Duration run_length;
+  public final transient Key key;
+
+  public AlbumInfoOrTrack(
+      String album_token,
+      String sort_key,
+      String album_title,
+      String artist_name,
+      LocalDate release_date,
+      String genre_name,
+      String track_title,
+      Duration run_length) {
+    this.album_token = album_token;
+    this.sort_key = sort_key;
+    this.album_title = album_title;
+    this.artist_name = artist_name;
+    this.release_date = release_date;
+    this.genre_name = genre_name;
+    this.track_title = track_title;
+    this.run_length = run_length;
+    key = new Key(album_token);
+  }
+
+  public AlbumInfo albumInfo() {
+    if (sort_key.equals("INFO_")) {
+      return new AlbumInfo(album_token, album_title, artist_name, release_date, genre_name);
+    }
+    return null;
+  }
+
+  public AlbumTrack albumTrack() {
+    if (sort_key.startsWith("TRACK_")) {
+      return new AlbumTrack(album_token, sort_key.substring("TRACK_".length()), track_title, run_length);
+    }
+    return null;
+  }
+
+  public static class Key {
+    public final String album_token;
+    public final String sort_key = "";
+
+    public Key(String album_token) {
+      this.album_token = album_token;
+    }
+  }
+}

--- a/samples/musiclibrary2/src/main/java/app/cash/tempest2/musiclibrary/java/AlbumInfoOrTrack.java
+++ b/samples/musiclibrary2/src/main/java/app/cash/tempest2/musiclibrary/java/AlbumInfoOrTrack.java
@@ -8,6 +8,7 @@ public class AlbumInfoOrTrack {
 
   @Attribute(name = "partition_key")
   public final String album_token;
+  @Attribute(noPrefix = true)
   public final String sort_key;
   public final String album_title;
   public final String artist_name;

--- a/samples/musiclibrary2/src/main/java/app/cash/tempest2/musiclibrary/java/MusicTable.java
+++ b/samples/musiclibrary2/src/main/java/app/cash/tempest2/musiclibrary/java/MusicTable.java
@@ -23,6 +23,7 @@ import app.cash.tempest2.SecondaryIndex;
 public interface MusicTable extends LogicalTable<MusicItem> {
   InlineView<AlbumInfo.Key, AlbumInfo> albumInfo();
   InlineView<AlbumTrack.Key, AlbumTrack> albumTracks();
+  InlineView<AlbumInfoOrTrack.Key, AlbumInfoOrTrack> albumInfoOrTracks();
 
   InlineView<PlaylistInfo.Key, PlaylistInfo> playlistInfo();
 

--- a/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicTable.kt
+++ b/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicTable.kt
@@ -29,6 +29,7 @@ import kotlin.text.toLong
 interface MusicTable : LogicalTable<MusicItem> {
   val albumInfo: InlineView<AlbumInfo.Key, AlbumInfo>
   val albumTracks: InlineView<AlbumTrack.Key, AlbumTrack>
+  val albumInfoOrTracks: InlineView<AlbumInfoOrTrack.Key, AlbumInfoOrTrack>
 
   val playlistInfo: InlineView<PlaylistInfo.Key, PlaylistInfo>
 
@@ -114,6 +115,42 @@ data class AlbumTrack(
     val track_title: String? = null,
     // To uniquely identify an item in pagination.
     val track_token: String? = null
+  )
+}
+
+data class AlbumInfoOrTrack(
+  @Attribute(name = "partition_key")
+  val album_token: String,
+  @Attribute(noPrefix = true)
+  val sort_key: String,
+  val album_title: String?,
+  val artist_name: String?,
+  val release_date: LocalDate?,
+  val genre_name: String?,
+  val track_title: String?,
+  val run_length: Duration?
+) {
+
+  @Transient
+  val key = Key(album_token, sort_key)
+
+  @Transient
+  val albumInfo: AlbumInfo? = if (sort_key == "INFO_") {
+    AlbumInfo(album_token, album_title!!, artist_name!!, release_date!!, genre_name!!)
+  } else {
+    null
+  }
+
+  @Transient
+  val albumTrack: AlbumTrack? = if (sort_key.startsWith("TRACK_")) {
+    AlbumTrack(album_token, sort_key.removePrefix("TRACK_"), track_title!!, run_length!!)
+  } else {
+    null
+  }
+
+  data class Key(
+    val album_token: String,
+    val sort_key: String = "",
   )
 }
 

--- a/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Annotation.kt
+++ b/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Annotation.kt
@@ -34,6 +34,7 @@ interface AttributeAnnotation<T : Annotation> {
   fun name(annotation: T): String
   fun names(annotation: T): Array<String>
   fun prefix(annotation: T): String
+  fun noPrefix(annotation: T): Boolean
 }
 
 internal fun AttributeAnnotation<*>.hasAttributeAnnotation(
@@ -50,13 +51,15 @@ internal fun <T : Annotation> AttributeAnnotation<T>.attributeMetadata(
   val annotation = findAnnotation(property, constructorParameters)
   return AttributeMetadata(
     annotation?.let(this::annotatedNames) ?: setOf(property.name),
-    annotation?.let(this::prefix) ?: ""
+    annotation?.let(this::prefix) ?: "",
+    annotation?.let(this::noPrefix) ?: false,
   )
 }
 
 internal data class AttributeMetadata(
   val names: Set<String>,
-  val prefix: String
+  val prefix: String,
+  val noPrefix: Boolean,
 )
 
 private fun <T : Annotation> AttributeAnnotation<T>.findAnnotation(

--- a/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Schema.kt
+++ b/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Schema.kt
@@ -217,6 +217,7 @@ data class ItemType(
     val propertyName: String,
     val names: Set<String>,
     val prefix: String,
+    val noPrefix: Boolean,
     val returnType: KType
   )
 
@@ -270,7 +271,7 @@ data class ItemType(
         requireNotNull(rangeKeyAttribute) {
           "Expect $itemType to map to ${rawItemType.type}'s range key ${primaryIndex.rangeKeyName}"
         }
-        require(rangeKeyAttribute.prefix.isNotEmpty()) {
+        require(rangeKeyAttribute.noPrefix || rangeKeyAttribute.prefix.isNotEmpty()) {
           "Expect $itemType.${primaryIndex.rangeKeyName} to be annotated with a prefix"
         }
       }
@@ -286,7 +287,7 @@ data class ItemType(
       if (property.shouldIgnore) {
         return null
       }
-      val (expectedRawItemAttributes, prefix) = attributeAnnotation.attributeMetadata(
+      val (expectedRawItemAttributes, prefix, noPrefix) = attributeAnnotation.attributeMetadata(
         property,
         constructorParameters
       )
@@ -296,7 +297,12 @@ data class ItemType(
             "${rawItemType.type}. But found ${rawItemType.propertyNames}. Use @Transient to exclude it."
         }
       }
-      return Attribute(property.name, expectedRawItemAttributes, prefix, property.returnType)
+      if (noPrefix) {
+        require(prefix.isEmpty()) {
+          "Expect $itemType.${property.name} to have no prefix."
+        }
+      }
+      return Attribute(property.name, expectedRawItemAttributes, prefix, noPrefix, property.returnType)
     }
   }
 }

--- a/tempest/src/main/kotlin/app/cash/tempest/Annotation.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/Annotation.kt
@@ -21,14 +21,15 @@ package app.cash.tempest
  *
  * If this mapped to a primary range key, it must have a prefix. Tempest
  * automatically adds the prefix before database writes and removes it after
- * database reads.
+ * database reads. To disable this behavior (not typesafe!), set `noPrefix` to true.
  */
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Attribute(
   val name: String = "",
   val names: Array<String> = [],
-  val prefix: String = ""
+  val prefix: String = "",
+  val noPrefix: Boolean = false,
 )
 
 /**

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/V1.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/V1.kt
@@ -34,6 +34,7 @@ internal object V1AttributeAnnotation : AttributeAnnotation<Attribute> {
   override fun name(annotation: Attribute) = annotation.name
   override fun names(annotation: Attribute) = annotation.names
   override fun prefix(annotation: Attribute) = annotation.prefix
+  override fun noPrefix(annotation: Attribute) = annotation.noPrefix
 }
 
 internal object V1StringAttributeValue : StringAttributeValue<AttributeValue> {

--- a/tempest/src/test/kotlin/app/cash/tempest/DynamoDbQueryableTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/DynamoDbQueryableTest.kt
@@ -18,6 +18,7 @@ package app.cash.tempest
 
 import app.cash.tempest.musiclibrary.AFTER_HOURS_EP
 import app.cash.tempest.musiclibrary.AlbumInfo
+import app.cash.tempest.musiclibrary.AlbumInfoOrTrack
 import app.cash.tempest.musiclibrary.AlbumTrack
 import app.cash.tempest.musiclibrary.LOCKDOWN_SINGLE
 import app.cash.tempest.musiclibrary.MusicDb
@@ -92,6 +93,20 @@ class DynamoDbQueryableTest {
     )
     assertThat(page2.hasMorePages).isFalse()
     assertThat(page2.trackTitles).containsAll(AFTER_HOURS_EP.trackTitles.slice(2..2))
+  }
+
+  @Test
+  fun primaryIndexBeginsWithMixedTypes() {
+    musicTable.givenAlbums(AFTER_HOURS_EP)
+
+    val page1 = musicTable.albumInfoOrTracks.query(
+      keyCondition = BeginsWith(AlbumInfoOrTrack.Key(AFTER_HOURS_EP.album_token))
+    )
+    assertThat(page1.hasMorePages).isFalse()
+    val albumInfo = page1.contents.mapNotNull { it.albumInfo }.single()
+    assertThat(albumInfo.album_title).isEqualTo(AFTER_HOURS_EP.album_title)
+    val albumTracks = page1.contents.mapNotNull { it.albumTrack }
+    assertThat(albumTracks.map { it.track_title }).containsAll(AFTER_HOURS_EP.trackTitles)
   }
 
   @Test

--- a/tempest/src/test/kotlin/app/cash/tempest/internal/SchemaTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/internal/SchemaTest.kt
@@ -99,6 +99,10 @@ class SchemaTest {
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.inlineView(Any::class, BadItem8::class)
     }.withMessage("Expect mapped properties of album_title to have the same type: [album_title, playlist_size]")
+
+    assertThatIllegalArgumentException().isThrownBy {
+      musicDb.music.inlineView(Any::class, BadItem9::class)
+    }.withMessage("Expect class app.cash.tempest.internal.BadItem9.sort_key to have no prefix.")
   }
 }
 
@@ -246,5 +250,18 @@ data class BadItem8(
   val genre_name: String
 ) {
   @Attribute(prefix = "INFO_")
+  val sort_key: String = ""
+}
+
+data class BadItem9(
+  @Attribute(name = "partition_key")
+  val album_token: String,
+  val album_title: String,
+  val artist_name: String,
+  val release_date: LocalDate,
+  val genre_name: String
+) {
+  // When `noPrefix` is true, `prefix` should be empty.
+  @Attribute(prefix = "INFO_", noPrefix = true)
   val sort_key: String = ""
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Annotation.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Annotation.kt
@@ -30,14 +30,15 @@ annotation class TableName(
  *
  * If this mapped to a primary range key, it must have a prefix. Tempest
  * automatically adds the prefix before database writes and removes it after
- * database reads.
+ * database reads. To disable this behavior (not typesafe!), set `noPrefix` to true.
  */
 @Target(AnnotationTarget.PROPERTY, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Attribute(
   val name: String = "",
   val names: Array<String> = [],
-  val prefix: String = ""
+  val prefix: String = "",
+  val noPrefix: Boolean = false,
 )
 
 /**

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
@@ -42,6 +42,7 @@ internal object V2AttributeAnnotation : AttributeAnnotation<Attribute> {
   override fun name(annotation: Attribute) = annotation.name
   override fun names(annotation: Attribute) = annotation.names
   override fun prefix(annotation: Attribute) = annotation.prefix
+  override fun noPrefix(annotation: Attribute) = annotation.noPrefix
 }
 
 internal object V2StringAttributeValue : StringAttributeValue<AttributeValue> {

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbQueryableTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbQueryableTest.kt
@@ -22,6 +22,7 @@ import app.cash.tempest.musiclibrary.THE_DARK_SIDE_OF_THE_MOON
 import app.cash.tempest.musiclibrary.THE_WALL
 import app.cash.tempest.musiclibrary.WHAT_YOU_DO_TO_ME_SINGLE
 import app.cash.tempest2.musiclibrary.AlbumInfo
+import app.cash.tempest2.musiclibrary.AlbumInfoOrTrack
 import app.cash.tempest2.musiclibrary.AlbumTrack
 import app.cash.tempest2.musiclibrary.MusicDb
 import app.cash.tempest2.musiclibrary.albumTitles
@@ -91,6 +92,20 @@ class DynamoDbQueryableTest {
     )
     assertThat(page2.hasMorePages).isFalse()
     assertThat(page2.trackTitles).containsAll(AFTER_HOURS_EP.trackTitles.slice(2..2))
+  }
+
+  @Test
+  fun primaryIndexBeginsWithMixedTypes() {
+    musicTable.givenAlbums(AFTER_HOURS_EP)
+
+    val page1 = musicTable.albumInfoOrTracks.query(
+      keyCondition = BeginsWith(AlbumInfoOrTrack.Key(AFTER_HOURS_EP.album_token))
+    )
+    assertThat(page1.hasMorePages).isFalse()
+    val albumInfo = page1.contents.mapNotNull { it.albumInfo }.single()
+    assertThat(albumInfo.album_title).isEqualTo(AFTER_HOURS_EP.album_title)
+    val albumTracks = page1.contents.mapNotNull { it.albumTrack }
+    assertThat(albumTracks.map { it.track_title }).containsAll(AFTER_HOURS_EP.trackTitles)
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/internal/SchemaTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/internal/SchemaTest.kt
@@ -99,6 +99,10 @@ class SchemaTest {
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.inlineView(Any::class, BadItem8::class)
     }.withMessage("Expect mapped properties of album_title to have the same type: [album_title, playlist_size]")
+
+    assertThatIllegalArgumentException().isThrownBy {
+      musicDb.music.inlineView(Any::class, BadItem9::class)
+    }.withMessage("Expect class app.cash.tempest2.internal.BadItem9.sort_key to have no prefix.")
   }
 }
 
@@ -246,5 +250,18 @@ data class BadItem8(
   val genre_name: String
 ) {
   @Attribute(prefix = "INFO_")
+  val sort_key: String = ""
+}
+
+data class BadItem9(
+  @Attribute(name = "partition_key")
+  val album_token: String,
+  val album_title: String,
+  val artist_name: String,
+  val release_date: LocalDate,
+  val genre_name: String
+) {
+  // When `noPrefix` is true, `prefix` should be empty.
+  @Attribute(prefix = "INFO_", noPrefix = true)
   val sort_key: String = ""
 }


### PR DESCRIPTION
To fetch multiple types in one query, developers would need to create a view that is a union type and has no sort key prefix. Example use cases include #16.

However, this was not possible on the primary index before because we enforce the primary index sort key to have a non empty prefix.

This PR relaxes that constraint. Developers can now annotate primary index sort keys with `@Attribute(noPrefix = true)`.

This PR also adds mixed type query code examples to the dev guide.