### PR TITLE
Cache reflection results

### DIFF
--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/AsyncLogicalDbFactory.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/AsyncLogicalDbFactory.kt
@@ -71,7 +71,7 @@ internal class AsyncLogicalDbFactory(
 
   override fun <T : AsyncLogicalTable<RI>, RI : Any> logicalTable(tableName: String, tableType: KClass<T>): T {
     val rawItemType = schema.addRawItem(tableName, tableType.rawItemType)
-    val tableSchema = TableSchema.fromClass(rawItemType.type.java)
+    val tableSchema = TableSchemaFactory.create<Any>(rawItemType.type.java)
     val dynamoDbTable = dynamoDbEnhancedClient.table(rawItemType.tableName, tableSchema)
     val logicalTable =
       object :

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -330,7 +330,7 @@ internal class DynamoDbLogicalDb(
     val rawItemType = schema.getRawItem(tableType)!!
     return mappedTableResourceFactory.mappedTableResource(
       rawItemType.tableName,
-      TableSchema.fromClass(rawItemType.type.java) as TableSchema<T>
+      TableSchemaFactory.create(rawItemType.type.java)
     )
   }
 

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/LogicalDbFactory.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/LogicalDbFactory.kt
@@ -71,7 +71,7 @@ internal class LogicalDbFactory(
 
   override fun <T : LogicalTable<RI>, RI : Any> logicalTable(tableName: String, tableType: KClass<T>): T {
     val rawItemType = schema.addRawItem(tableName, tableType.rawItemType)
-    val tableSchema = TableSchema.fromClass(rawItemType.type.java)
+    val tableSchema = TableSchemaFactory.create<Any>(rawItemType.type.java)
     val dynamoDbTable = dynamoDbEnhancedClient.table(rawItemType.tableName, tableSchema)
     val logicalTable =
       object :

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/TableSchemaFactory.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/TableSchemaFactory.kt
@@ -1,0 +1,20 @@
+package app.cash.tempest2.internal
+
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema
+import java.util.concurrent.ConcurrentHashMap
+
+object TableSchemaFactory {
+
+  private val schemas = ConcurrentHashMap<Class<*>, TableSchema<*>>()
+
+  /**
+   * Compute the TableSchema, which a moderately expensive operation, and cache the result.
+   */
+  fun <T> create(clazz: Class<*>): TableSchema<T> {
+    return schemas.getOrPut(clazz) { TableSchema.fromClass(clazz) } as TableSchema<T>
+  }
+
+  inline fun <reified T> create(): TableSchema<T> {
+    return create(T::class.java)
+  }
+}

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
@@ -58,7 +58,7 @@ internal class V2MapAttributeValue<DB : Any>(
 
   object Factory : MapAttributeValue.Factory {
     override fun <T : Any, DB : Any> create(type: KClass<DB>): MapAttributeValue<T, DB> {
-      return V2MapAttributeValue(TableSchema.fromClass(type.java)) as MapAttributeValue<T, DB>
+      return V2MapAttributeValue(TableSchemaFactory.create(type.java)) as MapAttributeValue<T, DB>
     }
   }
 }
@@ -66,7 +66,7 @@ internal class V2MapAttributeValue<DB : Any>(
 internal class V2RawItemTypeFactory : RawItemType.Factory {
 
   override fun create(tableName: String, rawItemType: KClass<*>): RawItemType {
-    val tableSchema = TableSchema.fromClass(rawItemType.java) as TableSchema<Any>
+    val tableSchema = TableSchemaFactory.create<Any>(rawItemType.java)
     return RawItemType(
       rawItemType as KClass<Any>,
       tableName,


### PR DESCRIPTION
This improves the performance of `tempest2`. 

In batch and transactional operations, tempest2 creates a `TableSchema` for each item it processes. Profiling has showed that `TableSchema.fromClass` is an expensive operation and this has caused excess allocation and GC pauses. This PR caches the results in memory.