### PR TITLE
Don't assume the dokka task exists.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ subprojects {
   }
 
   afterEvaluate {
-    val dokka by tasks.getting(DokkaTask::class) {
+    tasks.withType(DokkaTask::class).configureEach {
       outputDirectory = "$rootDir/docs/1.x/"
       outputFormat = "gfm"
       externalDocumentationLink {


### PR DESCRIPTION
For square internal publication, the dokka plugin is stripped out.
The build script is currently written in a way that assumes the
dokka task exists; this change makes it more robust in the case
where the dokka plugin is removed and the task doesn't exist.
See https://cash.slack.com/archives/C01M5M297T7/p1634649473313200?thread_ts=1634570479.292600&cid=C01M5M297T7
for additional context.