### PR TITLE
Upgrade spotless to a 5.x version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
     classpath(Dependencies.kotlinGradlePlugin)
     classpath(Dependencies.mavenPublishGradlePlugin)
     classpath(Dependencies.shadowJarPlugin)
-    classpath(Dependencies.spotlessPlugin)
+    classpath(Dependencies.spotless5Plugin)
     classpath(Dependencies.wireGradlePlugin)
   }
 }
@@ -22,7 +22,7 @@ buildscript {
 subprojects {
   apply(plugin = "java")
   apply(plugin = "kotlin")
-  apply(plugin = "com.diffplug.gradle.spotless")
+  apply(plugin = "com.diffplug.spotless")
   apply(plugin = "org.jetbrains.dokka")
 
   repositories {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,7 +26,7 @@ object Dependencies {
   val okio = "com.squareup.okio:okio:2.10.0"
   val shadowJarPlugin = "com.github.jengelman.gradle.plugins:shadow:6.1.0"
   val log4jCore = "org.apache.logging.log4j:log4j-core:2.15.0"
-  val spotlessPlugin = "com.diffplug.spotless:spotless-plugin-gradle:4.5.1"
+  val spotless5Plugin = "com.diffplug.spotless:spotless-plugin-gradle:5.7.0"
   val wireGradlePlugin = "com.squareup.wire:wire-gradle-plugin:3.6.0"
 }
 // Auto-generated from polyrepo's master-dependencies.json. Update via polyrepo dep-add and polyrepo dep-upgrade.


### PR DESCRIPTION
This helps with publishing the internal square snapshot
release.