### PR TITLE
Update log4j version to 2.16.0.

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -25,7 +25,7 @@ object Dependencies {
   val nettyBom = "io.netty:netty-bom:4.1.34.Final"
   val okio = "com.squareup.okio:okio:2.10.0"
   val shadowJarPlugin = "com.github.jengelman.gradle.plugins:shadow:6.1.0"
-  val log4jCore = "org.apache.logging.log4j:log4j-core:2.15.0"
+  val log4jCore = "org.apache.logging.log4j:log4j-core:2.16.0"
   val spotless5Plugin = "com.diffplug.spotless:spotless-plugin-gradle:5.7.0"
   val wireGradlePlugin = "com.squareup.wire:wire-gradle-plugin:3.6.0"
 }


### PR DESCRIPTION
This provides better security against the RCE vuln that was
partially fixed in 2.15.0.