### PR TITLE
Do not apply prefixer to keys in the offset for scan

### DIFF
--- a/tempest/src/main/kotlin/app/cash/tempest/Codec.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/Codec.kt
@@ -23,6 +23,6 @@ package app.cash.tempest
  * converted to the target type. If it cannot be, the behavior of this codec is undefined.
  */
 interface Codec<A : Any, D : Any> {
-  fun toDb(appItem: A): D
-  fun toApp(dbItem: D): A
+  fun toDb(appItem: A, skipPrefixer: Boolean? = false): D
+  fun toApp(dbItem: D, skipPrefixer: Boolean? = false): A
 }

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDBScannable.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/DynamoDBScannable.kt
@@ -77,13 +77,13 @@ internal class DynamoDBScannable<K : Any, I : Any>(
   }
 
   private fun Offset<K>.encodeOffset(): Map<String, AttributeValue> {
-    val offsetKey = keyCodec.toDb(key)
+    val offsetKey = keyCodec.toDb(key, true)
     return tableModel.convert(offsetKey)
   }
 
   private fun Map<String, AttributeValue>.decodeOffset(): Offset<K> {
     val offsetKeyAttributes = tableModel.unconvert(this)
-    val offsetKey = keyCodec.toApp(offsetKeyAttributes)
+    val offsetKey = keyCodec.toApp(offsetKeyAttributes, true)
     return Offset(offsetKey)
   }
 }

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/LogicalDbFactory.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/LogicalDbFactory.kt
@@ -205,8 +205,8 @@ internal class LogicalDbFactory(
   private class CodecAdapter<A : Any, D : Any>(
     private val internal: Codec<A, D>
   ) : app.cash.tempest.Codec<A, D> {
-    override fun toDb(appItem: A): D = internal.toDb(appItem)
-    override fun toApp(dbItem: D): A = internal.toApp(dbItem)
+    override fun toDb(appItem: A, skipPrefixer: Boolean?): D = internal.toDb(appItem, skipPrefixer)
+    override fun toApp(dbItem: D, skipPrefixer: Boolean?): A = internal.toApp(dbItem, skipPrefixer)
   }
 
   companion object {

--- a/tempest/src/test/kotlin/app/cash/tempest/CodecTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/CodecTest.kt
@@ -123,6 +123,26 @@ class CodecTest {
   }
 
   @Test
+  internal fun keyCodecSkipPrefixer() {
+    val keyCodec = musicTable.codec(AlbumInfo.Key::class)
+
+    val musicItem = MusicItem().apply {
+      partition_key = "ALBUM_1"
+      sort_key = "TRACK_0000000000000001"
+    }
+
+    // Apply AlbumInfo.Key codec to an AlbumTrack.Key by skipping prefixer.
+    // This can happen in a scan.
+    val appKey = keyCodec.toApp(musicItem, true)
+    assertThat(appKey.album_token).isEqualTo("ALBUM_1")
+    assertThat(appKey.sort_key).isEqualTo("TRACK_0000000000000001")
+
+    val dbKey = keyCodec.toDb(appKey, true)
+    assertThat(dbKey.partition_key).isEqualTo("ALBUM_1")
+    assertThat(dbKey.sort_key).isEqualTo("TRACK_0000000000000001")
+  }
+
+  @Test
   internal fun unexpectedType() {
     assertThatIllegalArgumentException().isThrownBy {
       musicTable.codec(AlbumColor::class)

--- a/tempest/src/test/kotlin/app/cash/tempest/DynamoDBScannableTest.kt
+++ b/tempest/src/test/kotlin/app/cash/tempest/DynamoDBScannableTest.kt
@@ -93,6 +93,8 @@ class DynamoDBScannableTest {
       pageSize = 20
     )
     assertThat(page1.hasMorePages).isTrue()
+    assertThat(page1.offset!!.key.album_token).isEqualTo(THE_WALL.album_token)
+    assertThat(page1.offset!!.key.track_token).isEqualTo("TRACK_0000000000000004")
     assertThat(page1.trackTitles).containsAll(expectedTrackTitles.slice(0..19))
 
     val page2 = musicTable.albumTracksByTitle.scan(

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Codec.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Codec.kt
@@ -23,6 +23,6 @@ package app.cash.tempest2
  * converted to the target type. If it cannot be, the behavior of this codec is undefined.
  */
 interface Codec<A : Any, D : Any> {
-  fun toDb(appItem: A): D
-  fun toApp(dbItem: D): A
+  fun toDb(appItem: A, skipPrefixer: Boolean? = false): D
+  fun toApp(dbItem: D, skipPrefixer: Boolean? = false): A
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbScannable.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbScannable.kt
@@ -108,13 +108,13 @@ internal class DynamoDbScannable<K : Any, I : Any, R : Any>(
   }
 
   private fun Offset<K>.encodeOffset(): Map<String, AttributeValue> {
-    val offsetKey = keyCodec.toDb(key)
+    val offsetKey = keyCodec.toDb(key, true)
     return tableSchema.itemToMap(offsetKey, true)
   }
 
   private fun Map<String, AttributeValue>.decodeOffset(): Offset<K> {
     val offsetKeyAttributes = tableSchema.mapToItem(this)
-    val offsetKey = keyCodec.toApp(offsetKeyAttributes)
+    val offsetKey = keyCodec.toApp(offsetKeyAttributes, true)
     return Offset(offsetKey)
   }
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
@@ -97,7 +97,7 @@ internal fun getTableName(member: ClassMember, dbType: KClass<*>): String {
 internal class CodecAdapter<A : Any, D : Any>(
   private val internal: Codec<A, D>
 ) : app.cash.tempest2.Codec<A, D> {
-  override fun toDb(appItem: A): D = internal.toDb(appItem)
+  override fun toDb(appItem: A, skipPrefixer: Boolean?): D = internal.toDb(appItem, skipPrefixer)
 
-  override fun toApp(dbItem: D): A = internal.toApp(dbItem)
+  override fun toApp(dbItem: D, skipPrefixer: Boolean?): A = internal.toApp(dbItem, skipPrefixer)
 }

--- a/tempest2/src/test/kotlin/app/cash/tempest2/CodecTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/CodecTest.kt
@@ -123,6 +123,26 @@ class CodecTest {
   }
 
   @Test
+  internal fun keyCodecSkipPrefixer() {
+    val keyCodec = musicDb.music.codec(AlbumInfo.Key::class)
+
+    val musicItem = MusicItem().apply {
+      partition_key = "ALBUM_1"
+      sort_key = "TRACK_0000000000000001"
+    }
+
+    // Apply AlbumInfo.Key codec to an AlbumTrack.Key by skipping prefixer.
+    // This can happen in a scan.
+    val appKey = keyCodec.toApp(musicItem, true)
+    assertThat(appKey.album_token).isEqualTo("ALBUM_1")
+    assertThat(appKey.sort_key).isEqualTo("TRACK_0000000000000001")
+
+    val dbKey = keyCodec.toDb(appKey, true)
+    assertThat(dbKey.partition_key).isEqualTo("ALBUM_1")
+    assertThat(dbKey.sort_key).isEqualTo("TRACK_0000000000000001")
+  }
+
+  @Test
   internal fun unexpectedType() {
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.codec(AlbumColor::class)

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbScannableTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbScannableTest.kt
@@ -72,6 +72,8 @@ class DynamoDbScannableTest {
       pageSize = 20
     )
     assertThat(page1.hasMorePages).isTrue()
+    assertThat(page1.offset!!.key.album_token).isEqualTo(THE_WALL.album_token)
+    assertThat(page1.offset!!.key.track_token).isEqualTo("TRACK_0000000000000004")
     assertThat(page1.trackTitles).containsAll(expectedTrackTitles.slice(0..19))
 
     val page2 = musicTable.albumTracksByTitle.scan(


### PR DESCRIPTION
Issue:

- A table has multiple entities with different prefixes, say entity A and entity B

-  Scan for  A, a page ends up at an item of B

- Since the Offset is A.Key, 1) removing the prefix is a no-op when returning the offset, 2) using the offset to the next scan, the prefix of A is added to the key -> this changes the start point.