### PR TITLE
Adds a pageWritten WritingPager.Handler method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ subprojects {
             kotlinOptions {
                 jvmTarget = "1.8"
                 allWarningsAsErrors = false
+                freeCompilerArgs = listOf("-Xjvm-default=all")
             }
         }
         val compileTestKotlin by tasks.getting(KotlinCompile::class) {

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
@@ -204,6 +204,8 @@ class KeySet private constructor(
   inline fun <reified K : Any> getKeys(): List<K> {
     return getKeys(K::class)
   }
+
+  override fun toString(): String = contents.toString()
 }
 
 /**
@@ -228,4 +230,6 @@ class ItemSet private constructor(
   inline fun <reified I : Any> getItems(): List<I> {
     return getItems(I::class)
   }
+
+  override fun toString(): String = contents.toString()
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/WritingPager.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/WritingPager.kt
@@ -75,7 +75,9 @@ class WritingPager<T> @JvmOverloads constructor(
     handler.finishPage(writeSet)
     check(writeSet.size <= maxTransactionItems) { "finishPage wrote too many items" }
 
-    db.transactionWrite(writeSet.build())
+    val page = writeSet.build()
+    db.transactionWrite(page)
+    handler.pageWritten(page)
 
     return appliedUpdates.size
   }
@@ -102,8 +104,18 @@ class WritingPager<T> @JvmOverloads constructor(
 
     /**
      * Invoked after a page of items has been computed.
+     *
+     * NB: the page has _not_ been written at this point. This method is called just prior
+     * to writing the page. Use [pageWritten] for handling a page after it has written successfully.
      */
     fun finishPage(builder: TransactionWriteSet.Builder)
+
+    /**
+     * Invoked after a page of items has been written.
+     */
+    fun pageWritten(writeSet: TransactionWriteSet) {
+      // default NOOP
+    }
   }
 }
 

--- a/tempest2/src/test/kotlin/app/cash/tempest2/WritingPagerTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/WritingPagerTest.kt
@@ -25,10 +25,14 @@ import app.cash.tempest2.musiclibrary.givenAlbums
 import app.cash.tempest2.musiclibrary.testDb
 import app.cash.tempest2.testing.logicalDb
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException
+import java.util.function.BiFunction
+import kotlin.streams.toList
 
 class WritingPagerTest {
 
@@ -50,25 +54,83 @@ class WritingPagerTest {
     )
     musicTable.playlistInfo.save(playlistV1)
 
+    val handler = AlbumTrackWritingPagerHandler(playlistV1.playlist_token, musicTable)
+
     musicDb.transactionWritingPager(
       tracks,
       maxTransactionItems = 10,
-      handler = AlbumTrackWritingPagerHandler(playlistV1.playlist_token, musicTable)
+      handler = handler
     ).execute()
 
     val playlistInfo = musicTable.playlistInfo.load(PlaylistInfo.Key(playlistV1.playlist_token))!!
     assertThat(playlistInfo.playlist_tracks).containsExactlyElementsOf(tracks)
     assertThat(playlistInfo.playlist_version).isEqualTo(4)
+
+    // We wrote 3 pages of up to 9 items each (1 of the 10 max is reserved for the playlist info)
+    assertThat(handler.eachPageCounter).isEqualTo(3)
+    assertThat(handler.itemCounterMap).isEqualTo(mapOf(0 to 9, 1 to 9, 2 to 7))
+    assertThat(handler.finishPageCounter).isEqualTo(3)
+    assertThat(handler.pageWrittenCounter).isEqualTo(3)
+    assertThat(handler.written).hasSize(3)
+  }
+
+  @Test
+  fun writeFails() {
+    musicTable.givenAlbums(THE_WALL)
+    val tracks = (1..25L).map { AlbumTrack.Key(THE_WALL.album_token, it) }
+    val playlistV1 = PlaylistInfo(
+      "PLAYLIST_1",
+      "Pink Floyd Anthology",
+      emptyList()
+    )
+    musicTable.playlistInfo.save(playlistV1)
+
+    val handler = AlbumTrackWritingPagerHandler(
+      playlistToken = playlistV1.playlist_token,
+      musicTable = musicTable,
+      currentVersionOffset = -1)
+
+    assertThatThrownBy {
+      musicDb.transactionWritingPager(
+        tracks,
+        maxTransactionItems = 10,
+        handler = handler
+      ).execute()
+    }.hasMessageContaining("Write transaction failed")
+      .isInstanceOf(TransactionCanceledException::class.java)
+
+    val playlistInfo = musicTable.playlistInfo.load(PlaylistInfo.Key(playlistV1.playlist_token))!!
+    assertThat(playlistInfo.playlist_tracks).isEmpty()
+    assertThat(playlistInfo.playlist_version).isEqualTo(1)
+
+    // We computed the first page of 10 items and then failed to write.
+    assertThat(handler.eachPageCounter).isEqualTo(1)
+    assertThat(handler.itemCounterMap).isEqualTo(mapOf(0 to 9))
+    assertThat(handler.finishPageCounter).isEqualTo(1)
+    assertThat(handler.pageWrittenCounter).isEqualTo(0)
+    assertThat(handler.written).isEmpty()
   }
 
   class AlbumTrackWritingPagerHandler(
     private val playlistToken: String,
-    private val musicTable: MusicTable
+    private val musicTable: MusicTable,
+    /** Offset the current version by this amount. Use a non-zero value to induce failure */
+    private val currentVersionOffset: Int = 0,
   ) : WritingPager.Handler<AlbumTrack.Key> {
     private lateinit var currentPagePlaylistInfo: PlaylistInfo
     private lateinit var currentPageTracks: List<AlbumTrack.Key>
 
+    var eachPageCounter = 0
+    var beforePageCounter = 0
+    // Records a count of items added by page number
+    var itemCounterMap : MutableMap<Int, Int> = mutableMapOf()
+    var finishPageCounter = 0
+    var pageWrittenCounter = 0
+
+    val written: MutableList<TransactionWriteSet> = mutableListOf()
+
     override fun eachPage(proceed: () -> Unit) {
+      eachPageCounter++
       proceed()
     }
 
@@ -76,6 +138,7 @@ class WritingPagerTest {
       remainingUpdates: List<AlbumTrack.Key>,
       maxTransactionItems: Int
     ): Int {
+      beforePageCounter++
       // Reserve 1 for the playlist info at the end.
       currentPageTracks = remainingUpdates.take((maxTransactionItems - 1))
       currentPagePlaylistInfo = musicTable.playlistInfo.load(PlaylistInfo.Key(playlistToken))!!
@@ -83,18 +146,26 @@ class WritingPagerTest {
     }
 
     override fun item(builder: TransactionWriteSet.Builder, item: AlbumTrack.Key) {
+      // Increment the item count for this page
+      itemCounterMap.merge(pageWrittenCounter, 1, Integer::sum)
       builder.checkCondition(item, trackExists())
     }
 
     override fun finishPage(builder: TransactionWriteSet.Builder) {
+      finishPageCounter++
       val playlistInfo = currentPagePlaylistInfo
       builder.save(
         playlistInfo.copy(
           playlist_tracks = playlistInfo.playlist_tracks + currentPageTracks,
           playlist_version = playlistInfo.playlist_version + 1
         ),
-        ifPlaylistVersionIs(playlistInfo.playlist_version)
+        ifPlaylistVersionIs(playlistInfo.playlist_version + currentVersionOffset)
       )
+    }
+
+    override fun pageWritten(writeSet: TransactionWriteSet) {
+      pageWrittenCounter++
+      written.add(writeSet)
     }
   }
 }


### PR DESCRIPTION
This adds a hook point for just after a page is written. (Somewhat confusingly, the existing `finishPage` method is invoked just prior to actually writing the page).

My immediate use case here is for capturing the time delta between initiating page computation and return from a successful write, but this also seems generically useful.