### PR TITLE
feat: support sparse, prefixed GSIs with Attribute.allowEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## [1.7.0] - 2023-05.03
+## [1.8.0] - 2023-05-31
+* New(tempest2): Adds `Attribute.allowEmpty` to support nullable, prefixed fields
+
+## [1.7.0] - 2023-05-03
 
 * New(gradle): Add Hermit
 * New: Add `pageWritten` hook to `WritingPager.Handler`
@@ -12,11 +15,11 @@
 * Chore(deps): Upgrade to Kotlin 1.7
 * Chore(gradle): Swap out kotlin-dsl for kotlin-jvm
 
-## [1.6.2] - 2022-04.01
+## [1.6.2] - 2022-04-01
 
 * Fixed: Fixing release, making sure we run the publication logic (#100)
 
-## [1.6.1] - 2022-04.01
+## [1.6.1] - 2022-04-01
 
 * Fixed: Fixing release logic (#99)
 

--- a/README.md
+++ b/README.md
@@ -486,13 +486,13 @@ public List<String> getAlbumTrackTitles(String albumToken) {
 For AWS SDK 1.x:
 
 ```groovy
-implementation "app.cash.tempest:tempest:1.7.0"
+implementation "app.cash.tempest:tempest:1.8.0"
 ```
 
 For AWS SDK 2.x:
 
 ```groovy
-implementation "app.cash.tempest:tempest2:1.7.0"
+implementation "app.cash.tempest:tempest2:1.8.0"
 ```
 
 ## Migrating From Tempest 1 to Tempest 2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 GROUP=app.cash.tempest
-VERSION_NAME=1.7.0-SNAPSHOT
+VERSION_NAME=1.8.0
 
 #org.gradle.jvmargs=-Xmx2024m
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ plugins:
 
 extra:
   versions:
-    tempest: '1.7.0'
+    tempest: '1.8.0'
 
 nav:
   - 'Overview': index.md

--- a/samples/musiclibrary-testing/src/main/kotlin/app/cash/tempest/musiclibrary/TestEntities.kt
+++ b/samples/musiclibrary-testing/src/main/kotlin/app/cash/tempest/musiclibrary/TestEntities.kt
@@ -192,13 +192,46 @@ val LOCKDOWN_SINGLE = Album(
   )
 )
 
+val SPIRIT_WORLD_FIELD_GUIDE = Album(
+  album_token = "ALBUM_a9d2b95a",
+  album_title = "Spirit World Field Guide",
+  artist_name = "Aesop Rock",
+  release_date = LocalDate.of(2020, 11, 13),
+  genre_name = "Hip-Hop",
+  tracks = listOf(
+    Track("Hello from the Spirit World", Duration.parse("PT2M06S")),
+    Track("The Gates", Duration.parse("PT3M51S")),
+    Track("Button Masher", Duration.parse("PT3M45S")),
+    Track("Dog at the Door", Duration.parse("PT1M28S")),
+    Track("Gauze", Duration.parse("PT3M12S")),
+    Track("Pizza Alley", Duration.parse("PT4M36S")),
+    Track("Crystal Sword", Duration.parse("PT2M20S")),
+    Track("Boot Soup", Duration.parse("PT4M08S")),
+    Track("Coveralls", Duration.parse("PT3M39S")),
+    Track("Jumping Coffin", Duration.parse("PT3M29S")),
+    Track("Holy Waterfall", Duration.parse("PT3M48S")),
+    Track("Flies", Duration.parse("PT0M46S")),
+    Track("Salt", Duration.parse("PT3M37S")),
+    Track("Sleeper Car", Duration.parse("PT3M42S")),
+    Track("1 to 10", Duration.parse("PT0M53S")),
+    Track("Attaboy", Duration.parse("PT3M00S")),
+    Track("Kodokushi", Duration.parse("PT3M53S")),
+    Track("Fixed and Dilated", Duration.parse("PT2M38S")),
+    Track("Side Quest", Duration.parse("PT1M21S")),
+    Track("Marble Cake", Duration.parse("PT4M16S")),
+    Track("The Four Winds", Duration.parse("PT2M50S")),
+    ),
+  label = "Rhymesayers"
+)
+
 data class Album(
   val album_token: String,
   val album_title: String,
   val artist_name: String,
   val release_date: LocalDate,
   val genre_name: String,
-  val tracks: List<Track>
+  val tracks: List<Track>,
+  val label: String? = null
 ) {
   val trackTitles = tracks.map { it.track_title }
 }

--- a/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicItem.kt
+++ b/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicItem.kt
@@ -33,7 +33,7 @@ import java.time.LocalDate
 class MusicItem {
   // All Items.
   @get:DynamoDbPartitionKey
-  @get:DynamoDbSecondarySortKey(indexNames = ["genre_album_index", "artist_album_index"])
+  @get:DynamoDbSecondarySortKey(indexNames = ["genre_album_index", "artist_album_index", "label_album_index"])
   var partition_key: String? = null
   @get:DynamoDbSortKey
   var sort_key: String? = null
@@ -46,6 +46,8 @@ class MusicItem {
   var release_date: LocalDate? = null
   @get:DynamoDbSecondaryPartitionKey(indexNames = ["genre_album_index"])
   var genre_name: String? = null
+  @get:DynamoDbSecondaryPartitionKey(indexNames = ["label_album_index"])
+  var label_name: String? = null
 
   // AlbumTrack.
   @get:DynamoDbSecondarySortKey(indexNames = ["album_track_title_index"])

--- a/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicTable.kt
+++ b/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicTable.kt
@@ -35,6 +35,7 @@ interface MusicTable : LogicalTable<MusicItem> {
   // Global Secondary Indexes.
   val albumInfoByGenre: SecondaryIndex<AlbumInfo.GenreIndexOffset, AlbumInfo>
   val albumInfoByArtist: SecondaryIndex<AlbumInfo.ArtistIndexOffset, AlbumInfo>
+  val albumInfoByLabel: SecondaryIndex<AlbumInfo.LabelIndexOffset, AlbumInfo>
 
   // Local Secondary Indexes.
   val albumTracksByTitle: SecondaryIndex<AlbumTrack.TitleIndexOffset, AlbumTrack>
@@ -46,7 +47,9 @@ data class AlbumInfo(
   val album_title: String,
   val artist_name: String,
   val release_date: LocalDate,
-  val genre_name: String
+  val genre_name: String,
+  @Attribute(prefix = "L_", allowEmpty = true)
+  val label_name: String? = null
 ) {
   @Attribute(prefix = "INFO_")
   val sort_key: String = ""
@@ -71,6 +74,14 @@ data class AlbumInfo(
   @ForIndex("artist_album_index")
   data class ArtistIndexOffset(
     val artist_name: String,
+    val album_token: String? = null,
+    // To uniquely identify an item in pagination.
+    val sort_key: String? = null
+  )
+
+  @ForIndex("label_album_index")
+  data class LabelIndexOffset(
+    val label_name: String,
     val album_token: String? = null,
     // To uniquely identify an item in pagination.
     val sort_key: String? = null

--- a/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Annotation.kt
+++ b/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Annotation.kt
@@ -34,6 +34,7 @@ interface AttributeAnnotation<T : Annotation> {
   fun name(annotation: T): String
   fun names(annotation: T): Array<String>
   fun prefix(annotation: T): String
+  fun allowEmpty(annotation: T): Boolean
 }
 
 internal fun AttributeAnnotation<*>.hasAttributeAnnotation(
@@ -50,13 +51,15 @@ internal fun <T : Annotation> AttributeAnnotation<T>.attributeMetadata(
   val annotation = findAnnotation(property, constructorParameters)
   return AttributeMetadata(
     annotation?.let(this::annotatedNames) ?: setOf(property.name),
-    annotation?.let(this::prefix) ?: ""
+    annotation?.let(this::prefix) ?: "",
+    annotation?.let(this::allowEmpty) ?: false
   )
 }
 
 internal data class AttributeMetadata(
   val names: Set<String>,
-  val prefix: String
+  val prefix: String,
+  val allowEmpty: Boolean
 )
 
 private fun <T : Annotation> AttributeAnnotation<T>.findAnnotation(

--- a/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Schema.kt
+++ b/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Schema.kt
@@ -217,7 +217,8 @@ data class ItemType(
     val propertyName: String,
     val names: Set<String>,
     val prefix: String,
-    val returnType: KType
+    val returnType: KType,
+    val allowEmpty: Boolean
   )
 
   interface Index {
@@ -286,7 +287,7 @@ data class ItemType(
       if (property.shouldIgnore) {
         return null
       }
-      val (expectedRawItemAttributes, prefix) = attributeAnnotation.attributeMetadata(
+      val (expectedRawItemAttributes, prefix, allowEmpty) = attributeAnnotation.attributeMetadata(
         property,
         constructorParameters
       )
@@ -298,7 +299,7 @@ data class ItemType(
             "See: https://github.com/cashapp/tempest/issues/53."
         }
       }
-      return Attribute(property.name, expectedRawItemAttributes, prefix, property.returnType)
+      return Attribute(property.name, expectedRawItemAttributes, prefix, property.returnType, allowEmpty)
     }
   }
 }

--- a/tempest/src/main/kotlin/app/cash/tempest/internal/V1.kt
+++ b/tempest/src/main/kotlin/app/cash/tempest/internal/V1.kt
@@ -34,6 +34,7 @@ internal object V1AttributeAnnotation : AttributeAnnotation<Attribute> {
   override fun name(annotation: Attribute) = annotation.name
   override fun names(annotation: Attribute) = annotation.names
   override fun prefix(annotation: Attribute) = annotation.prefix
+  override fun allowEmpty(annotation: Attribute) = false
 }
 
 internal object V1StringAttributeValue : StringAttributeValue<AttributeValue> {

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Annotation.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Annotation.kt
@@ -37,7 +37,9 @@ annotation class TableName(
 annotation class Attribute(
   val name: String = "",
   val names: Array<String> = [],
-  val prefix: String = ""
+  val prefix: String = "",
+  /** Allows a nullable field with a [prefix] to be null when serializing. If this is [false] the [prefix] will be added to the field even when it is [null]. */
+  val allowEmpty: Boolean = false
 )
 
 /**

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/V2.kt
@@ -42,6 +42,7 @@ internal object V2AttributeAnnotation : AttributeAnnotation<Attribute> {
   override fun name(annotation: Attribute) = annotation.name
   override fun names(annotation: Attribute) = annotation.names
   override fun prefix(annotation: Attribute) = annotation.prefix
+  override fun allowEmpty(annotation: Attribute) = annotation.allowEmpty
 }
 
 internal object V2StringAttributeValue : StringAttributeValue<AttributeValue> {

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbQueryableTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbQueryableTest.kt
@@ -21,6 +21,7 @@ import app.cash.tempest.musiclibrary.LOCKDOWN_SINGLE
 import app.cash.tempest.musiclibrary.THE_DARK_SIDE_OF_THE_MOON
 import app.cash.tempest.musiclibrary.THE_WALL
 import app.cash.tempest.musiclibrary.WHAT_YOU_DO_TO_ME_SINGLE
+import app.cash.tempest.musiclibrary.SPIRIT_WORLD_FIELD_GUIDE
 import app.cash.tempest2.musiclibrary.AlbumInfo
 import app.cash.tempest2.musiclibrary.AlbumTrack
 import app.cash.tempest2.musiclibrary.MusicDb
@@ -255,7 +256,8 @@ class DynamoDbQueryableTest {
     musicTable.givenAlbums(
       WHAT_YOU_DO_TO_ME_SINGLE,
       AFTER_HOURS_EP,
-      LOCKDOWN_SINGLE
+      LOCKDOWN_SINGLE,
+      SPIRIT_WORLD_FIELD_GUIDE
     )
     val page1 = musicTable.albumInfoByArtist.query(
       BeginsWith(AlbumInfo.ArtistIndexOffset("53 Theives", "")),
@@ -266,6 +268,7 @@ class DynamoDbQueryableTest {
       AFTER_HOURS_EP.album_title,
       WHAT_YOU_DO_TO_ME_SINGLE.album_title
     )
+    assertThat(page1.contents.map { it.label_name }.filterNotNull().size).isEqualTo(0)
 
     val page2 = musicTable.albumInfoByArtist.query(
       BeginsWith(AlbumInfo.ArtistIndexOffset("53 Theives", "")),
@@ -276,6 +279,18 @@ class DynamoDbQueryableTest {
     assertThat(page2.albumTitles).containsExactly(
       LOCKDOWN_SINGLE.album_title
     )
+    assertThat(page2.contents.map { it.label_name }.filterNotNull().size).isEqualTo(0)
+
+    val sparseGsiPage = musicTable.albumInfoByLabel.query(
+      BeginsWith(AlbumInfo.LabelIndexOffset("Rhymesayers", "")),
+      pageSize = 1
+    )
+
+    assertThat(sparseGsiPage.hasMorePages).isTrue()
+    assertThat(sparseGsiPage.albumTitles).containsExactly(
+      SPIRIT_WORLD_FIELD_GUIDE.album_title
+    )
+    assertThat(sparseGsiPage.contents.single().label_name).isEqualTo(SPIRIT_WORLD_FIELD_GUIDE.label)
   }
 
   private fun runLengthLongerThan(duration: Duration): Expression {

--- a/tempest2/src/test/kotlin/app/cash/tempest2/internal/SchemaTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/internal/SchemaTest.kt
@@ -51,7 +51,7 @@ class SchemaTest {
 
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.secondaryIndex(BadIndexOffset4::class, AlbumInfo::class)
-    }.withMessage("Expect nonexistent_attribute, required by class app.cash.tempest2.internal.BadIndexOffset4, to be declared in class app.cash.tempest2.musiclibrary.AlbumInfo. But found [album_title, album_token, artist_name, genre_name, release_date, sort_key]. Use @Transient to exclude it.")
+    }.withMessage("Expect nonexistent_attribute, required by class app.cash.tempest2.internal.BadIndexOffset4, to be declared in class app.cash.tempest2.musiclibrary.AlbumInfo. But found [album_title, album_token, artist_name, genre_name, label_name, release_date, sort_key]. Use @Transient to exclude it.")
 
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.secondaryIndex(BadIndexOffset5::class, AlbumInfo::class)
@@ -86,7 +86,7 @@ class SchemaTest {
 
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.inlineView(Any::class, BadItem5::class)
-    }.withMessage("Expect nonexistent_attribute, required by class app.cash.tempest2.internal.BadItem5, to be declared in class app.cash.tempest2.musiclibrary.MusicItem. But found [album_title, artist_name, genre_name, partition_key, playlist_name, playlist_size, playlist_tracks, playlist_version, release_date, run_length, sort_key, track_title, track_token]. Use @Transient to exclude it. You might see this error message if the property name starts with `is`. See: https://github.com/cashapp/tempest/issues/53.")
+    }.withMessage("Expect nonexistent_attribute, required by class app.cash.tempest2.internal.BadItem5, to be declared in class app.cash.tempest2.musiclibrary.MusicItem. But found [album_title, artist_name, genre_name, label_name, partition_key, playlist_name, playlist_size, playlist_tracks, playlist_version, release_date, run_length, sort_key, track_title, track_token]. Use @Transient to exclude it. You might see this error message if the property name starts with `is`. See: https://github.com/cashapp/tempest/issues/53.")
 
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.inlineView(Any::class, BadItem6::class)


### PR DESCRIPTION
Currently Tempest will add an `Attribute.prefix` to a field even if it is nullable and `null`. This causes two issues

1. [removePrefix](https://github.com/cashapp/tempest/blob/96fc15ebeb0684a8fcaa44b1fb731fcf983fdb71/tempest-internal/src/main/kotlin/app/cash/tempest/internal/Codec.kt#L136) fails with a nullable value
2. Sparse GSIs cannot be used, since the value will always include the `prefix`

Since it is possible that existing users are relying on the `prefix` being added to null fields changing this behavior would be a breaking change, as the field would stop being written.

This PR introduces a new `Attribute.allowEmpty` flag that defaults to `false`. When it is `true` and the field is set to `null` it will not have the `prefix` added, and checks against the field (such as query construction) will skip it.

This is currently causing issues for CashApp users ([internal slack thread](https://cash.slack.com/archives/C01G7QB4ANQ/p1685118751485779))