### PR TITLE
Remove enforcedPlatform

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -3,7 +3,7 @@ name: Publish a release
 on:
   push:
     branches:
-      - allowEnforced
+      - main
     tags:
       - '*'
 

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -3,7 +3,7 @@ name: Publish a release
 on:
   push:
     branches:
-      - main
+      - allowEnforced
     tags:
       - '*'
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ subprojects {
         }
 
         dependencies {
-            add("api", project(":tempest-bom"))
+            // add("api", project(":tempest-bom"))
             add("api", platform(Dependencies.nettyBom))
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ allprojects {
 }
 
 subprojects {
+    if (project.name == "tempest-bom") return@subprojects
+
     apply(plugin = "org.jetbrains.dokka")
 
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ subprojects {
             add("api", enforcedPlatform(project(":tempest-bom")))
             add("api", platform(Dependencies.nettyBom))
         }
+
+        tasks.withType<GenerateModuleMetadata> {
+            suppressedValidationErrors.add("enforced-platform")
+        }
     }
 
     tasks.withType<JavaCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,12 +52,8 @@ subprojects {
         }
 
         dependencies {
-            add("api", enforcedPlatform(project(":tempest-bom")))
+            add("api", project(":tempest-bom"))
             add("api", platform(Dependencies.nettyBom))
-        }
-
-        tasks.withType<GenerateModuleMetadata> {
-            suppressedValidationErrors.add("enforced-platform")
         }
     }
 


### PR DESCRIPTION
per guidance

```
 In general publishing dependencies to enforced platforms is a mistake: enforced platforms shouldn't be used for published components because they behave like forced dependencies and leak to consumers. This can result in hard to diagnose dependency resolution errors. If you did this intentionally you can disable this check by adding 'enforced-platform' to the suppressed validations of the :tempest-internal:generateMetadataFileForMavenPublication task
 ```
 
 Setting this as un-enforced caused another error
 
 ```
   > No matching variant of project :tempest-bom was found. The consumer was configured to find an API of a library compatible with Java 8, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' but:
          - Variant 'apiElements' capability app.cash.tempest:tempest-bom:1.8.0-SNAPSHOT declares an API of a component:
              - Incompatible because this component declares a platform and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
                  - Doesn't say anything about org.jetbrains.kotlin.platform.type (required 'jvm')
          - Variant 'enforcedApiElements' capability app.cash.tempest:tempest-bom-derived-enforced-platform:1.8.0-SNAPSHOT declares an API of a component:
              - Incompatible because this component declares an enforced platform and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
                  - Doesn't say anything about org.jetbrains.kotlin.platform.type (required 'jvm')
          - Variant 'enforcedRuntimeElements' capability app.cash.tempest:tempest-bom-derived-enforced-platform:1.8.0-SNAPSHOT declares a runtime of a component:
              - Incompatible because this component declares an enforced platform and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
                  - Doesn't say anything about org.jetbrains.kotlin.platform.type (required 'jvm')
          - Variant 'runtimeElements' capability app.cash.tempest:tempest-bom:1.8.0-SNAPSHOT declares a runtime of a component:
              - Incompatible because this component declares a platform and the consumer needed a library
              - Other compatible attributes:
                  - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                  - Doesn't say anything about its target Java environment (preferred optimized for standard JVMs)
                  - Doesn't say anything about its target Java version (required compatibility with Java 8)
                  - Doesn't say anything about its elements (required them preferably in the form of class files)
                  - Doesn't say anything about org.jetbrains.kotlin.platform.type (required 'jvm')
                  ```
                  
So I have removed this dependency entirely.