### PR TITLE
docs: add a note explaining the need for an empty base type

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ public class AlbumTrack {
 
 You build business logic with logical types. Tempest handles mapping them to the underlying persistence type.
 
+> Note: The base item type `MusicLibraryItem` is still used for the `LogicalTable`. This type is intended to model an empty row, so all its fields should be nullable with a `null` default value. Using non-nullable types or fields with default values will cause issues during serialization and querying.
+
 #### Kotlin
 
 ```kotlin

--- a/docs/guide/getting_started.md
+++ b/docs/guide/getting_started.md
@@ -116,6 +116,8 @@ To access this table in code, model it using
 [`DynamoDBMapper`](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBMapper.html) or 
 [`DynamoDbEnhancedClient`](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.html).
 
+> Note: The base item type `AliasItem` is still used for the `LogicalTable`. This type is intended to model an empty row, so all its fields should be nullable with a `null` default value. Using non-nullable types or fields with default values will cause issues during serialization and querying.
+
 === "Kotlin - SDK 2.x"
 
     ```kotlin


### PR DESCRIPTION
A used reported an issue where an `Offset` that contained a default value was breaking querying, since the value was included in the `initialOffset` value during paging. While the current docs make some allusions to the base type being nullable, they never state this is a requirement. This note should address that.