### PR TITLE
Revert "Prepare for release 1.10.1 (#158)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Change Log
 
-## [1.10.1] - 2023-08-16
-* Fix: Initialize the dynamodb clients immediately to avoid DI issues in consumers
-
 ## [1.10.0] - 2023-06-06
 * Fix: Async Batch support for multiple pages
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 GROUP=app.cash.tempest
-VERSION_NAME=1.10.1
+VERSION_NAME=1.10.0-SNAPSHOT
 
 #org.gradle.jvmargs=-Xmx2024m
 


### PR DESCRIPTION
This reverts commit 996c49fa1b9902687827a8b4cdec18cbfc91f8e0.

Releasing is too complicated with tags and forks, just going to revert since pretty sure nothing happened.