### PR TITLE
Improve handling of TransactionCanceledException by avoid creating new instance of it from scratch

### DIFF
--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -345,9 +345,8 @@ internal class DynamoDbLogicalDb(
     // We don't want to wrap these exceptions but only add a more useful message so upstream callers can themselves
     // parse the potentially concurrency related TransactionCancelledExceptions
     // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/model/TransactionCanceledException.html
-    throw TransactionCanceledException.builder()
+    throw e.toBuilder()
       .message("Write transaction failed: ${writeSet.describeOperations()}")
-      .cancellationReasons(e.cancellationReasons())
       .build()
   }
 

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -347,7 +347,8 @@ internal class DynamoDbLogicalDb(
     // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/model/TransactionCanceledException.html
     throw TransactionCanceledException.builder()
       .message(
-        "Write transaction failed: ${writeSet.describeOperations()}. Aws error message: ${e.message}"
+        "Write transaction failed: ${writeSet.describeOperations()}.\n" +
+          " Aws error message: ${e.message}"
       )
       .cancellationReasons(e.cancellationReasons())
       .build()

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -345,8 +345,11 @@ internal class DynamoDbLogicalDb(
     // We don't want to wrap these exceptions but only add a more useful message so upstream callers can themselves
     // parse the potentially concurrency related TransactionCancelledExceptions
     // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/model/TransactionCanceledException.html
-    throw e.toBuilder()
-      .message("Write transaction failed: ${writeSet.describeOperations()}")
+    throw TransactionCanceledException.builder()
+      .message(
+        "Write transaction failed: ${writeSet.describeOperations()}. Aws error message: ${e.message}"
+      )
+      .cancellationReasons(e.cancellationReasons())
       .build()
   }
 


### PR DESCRIPTION
The `toTransactionWriteException` function in `DynamoDbLogicalDb` class intends to decorate the exception with a meaningful `message` without wrapping the AWS exception, but in this process completely creates the exception instance from scratch. We can create the exception instance with the builder by using `toBuilder()` function which would use the current state of the exception.