### PR TITLE
Add APIs to execute batch, query and load requests along with consumed capacity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ kotlin = "1.7.10"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
-aws2Dynamodb = { module = "software.amazon.awssdk:dynamodb", version = "2.17.134" }
-aws2DynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version = "2.17.134" }
+aws2Dynamodb = { module = "software.amazon.awssdk:dynamodb", version = "2.25.11" }
+aws2DynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version = "2.25.11" }
 awsDynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version = "1.11.960" }
 awsDynamodbLocal = { module = "com.amazonaws:DynamoDBLocal", version = "1.13.5" }
 clikt = { module = "com.github.ajalt:clikt", version = "2.8.0" }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncLogicalDb.kt
@@ -50,24 +50,11 @@ interface AsyncLogicalDb : AsyncLogicalTable.Factory {
   suspend fun batchLoad(
     keys: KeySet,
     consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ
-  ): ItemSet =
-    batchLoadAsync(keys, consistentReads, maxPageSize).asFlow().reduce { acc, item ->
-      ItemSet(acc.getAllItems() + item.getAllItems())
-    }
-
-  suspend fun batchLoadWithCapacity(
-    keys: KeySet,
-    consistentReads: Boolean = false,
     maxPageSize: Int = MAX_BATCH_READ,
-    returnConsumedCapacity: ReturnConsumedCapacity
-  ): ResultWithCapacityConsumed<ItemSet> =
-    batchLoadAsyncWithCapacity(keys, consistentReads, maxPageSize, returnConsumedCapacity).asFlow().reduce { acc, item ->
-      ResultWithCapacityConsumed(
-      ItemSet(
-        acc.results.getAllItems() + item.results.getAllItems()),
-        acc.consumedCapacity + item.consumedCapacity
-      )
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
+  ): ItemSet =
+    batchLoadAsync(keys, consistentReads, maxPageSize, returnConsumedCapacity).asFlow().reduce { acc, item ->
+      ItemSet(acc.getAllItems() + item.getAllItems())
     }
 
   suspend fun batchLoad(
@@ -174,30 +161,27 @@ interface AsyncLogicalDb : AsyncLogicalTable.Factory {
   fun batchLoadAsync(
     keys: KeySet,
     consistentReads: Boolean,
-    maxPageSize: Int
-  ): Publisher<ItemSet>
-
-  fun batchLoadAsyncWithCapacity(
-    keys: KeySet,
-    consistentReads: Boolean,
     maxPageSize: Int,
     returnConsumedCapacity: ReturnConsumedCapacity
-  ): Publisher<ResultWithCapacityConsumed<ItemSet>>
+  ): Publisher<ItemSet>
 
   fun batchLoadAsync(
     keys: KeySet,
-    consistentReads: Boolean
-  ) = batchLoadAsync(keys, consistentReads, MAX_BATCH_READ)
+    consistentReads: Boolean,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
+  ) = batchLoadAsync(keys, consistentReads, MAX_BATCH_READ, returnConsumedCapacity)
 
   fun batchLoadAsync(
     keys: Iterable<Any>,
-    consistentReads: Boolean
-  ) = batchLoadAsync(KeySet(keys), consistentReads, MAX_BATCH_READ)
+    consistentReads: Boolean,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
+  ) = batchLoadAsync(KeySet(keys), consistentReads, returnConsumedCapacity)
 
   fun batchLoadAsync(
     vararg keys: Any,
-    consistentReads: Boolean
-  ) = batchLoadAsync(keys.toList(), consistentReads)
+    consistentReads: Boolean,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
+  ) = batchLoadAsync(keys.toList(), consistentReads, returnConsumedCapacity)
 
   fun batchLoadAsync(
     keys: Iterable<Any>

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncLogicalDb.kt
@@ -162,7 +162,7 @@ interface AsyncLogicalDb : AsyncLogicalTable.Factory {
     keys: KeySet,
     consistentReads: Boolean,
     maxPageSize: Int,
-    returnConsumedCapacity: ReturnConsumedCapacity
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
   ): Publisher<ItemSet>
 
   fun batchLoadAsync(

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncQuery.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncQuery.kt
@@ -19,6 +19,7 @@ package app.cash.tempest2
 import kotlinx.coroutines.reactive.awaitFirst
 import org.reactivestreams.Publisher
 import software.amazon.awssdk.enhanced.dynamodb.Expression
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 
 interface AsyncQueryable<K : Any, I : Any> {
 
@@ -32,8 +33,17 @@ interface AsyncQueryable<K : Any, I : Any> {
     pageSize: Int = 100,
     consistentRead: Boolean = false,
     filterExpression: Expression? = null,
-    initialOffset: Offset<K>? = null
-  ): Page<K, I> = queryAsync(keyCondition, asc, pageSize, consistentRead, filterExpression, initialOffset).awaitFirst()
+    initialOffset: Offset<K>? = null,
+    returnConsumedCapacity: ReturnConsumedCapacity? = null,
+  ): Page<K, I> = queryAsync(
+    keyCondition,
+    asc,
+    pageSize,
+    consistentRead,
+    filterExpression,
+    initialOffset,
+    returnConsumedCapacity
+  ).awaitFirst()
 
   // Overloaded functions for Java callers (Kotlin interfaces do not support `@JvmOverloads`).
 
@@ -43,7 +53,8 @@ interface AsyncQueryable<K : Any, I : Any> {
     pageSize: Int,
     consistentRead: Boolean,
     filterExpression: Expression?,
-    initialOffset: Offset<K>?
+    initialOffset: Offset<K>?,
+    returnConsumedCapacity: ReturnConsumedCapacity?,
   ): Publisher<Page<K, I>>
 
   fun queryAsync(keyCondition: KeyCondition<K>) = queryAsync(
@@ -67,13 +78,14 @@ interface AsyncQueryable<K : Any, I : Any> {
   fun queryAsync(
     keyCondition: KeyCondition<K>,
     config: QueryConfig,
-    initialOffset: Offset<K>?
+    initialOffset: Offset<K>?,
   ) = queryAsync(
     keyCondition,
     config.asc,
     config.pageSize,
     config.consistentRead,
     config.filterExpression,
-    initialOffset
+    initialOffset,
+    config.returnConsumedCapacity
   )
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
@@ -35,7 +35,7 @@ interface AsyncView<K : Any, I : Any> {
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
-  ): Pair<I?, ConsumedCapacity> = loadAsyncWithConsumedCapacity(key, consistentReads, returnConsumedCapacity).await()
+  ): Pair<I?, ConsumedCapacity?> = loadAsyncWithConsumedCapacity(key, consistentReads, returnConsumedCapacity).await()
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear
@@ -80,7 +80,7 @@ interface AsyncView<K : Any, I : Any> {
     key: K,
     consistentReads: Boolean,
     returnConsumedCapacity: ReturnConsumedCapacity
-  ): CompletableFuture<Pair<I?, ConsumedCapacity>>
+  ): CompletableFuture<Pair<I?, ConsumedCapacity?>>
 
   fun loadAsync(key: K) = loadAsync(key, false)
 

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.future.await
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import java.util.concurrent.CompletableFuture
 
 interface AsyncView<K : Any, I : Any> {
@@ -28,6 +29,8 @@ interface AsyncView<K : Any, I : Any> {
    * such item exists.
    */
   suspend fun load(key: K, consistentReads: Boolean = false): I? = loadAsync(key, consistentReads).await()
+
+  suspend fun loadWithCapacity(key: K, consistentReads: Boolean = false, returnConsumedCapacity: ReturnConsumedCapacity): ResultWithCapacityConsumed<I?> = loadAsyncWithCapacity(key, consistentReads, returnConsumedCapacity).await()
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear
@@ -67,6 +70,7 @@ interface AsyncView<K : Any, I : Any> {
   // Overloaded functions for Java callers (Kotlin interfaces do not support `@JvmOverloads`).
 
   fun loadAsync(key: K, consistentReads: Boolean): CompletableFuture<I?>
+  fun loadAsyncWithCapacity(key: K, consistentReads: Boolean, returnConsumedCapacity: ReturnConsumedCapacity): CompletableFuture<ResultWithCapacityConsumed<I?>>
 
   fun loadAsync(key: K) = loadAsync(key, false)
 

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.future.await
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import java.util.concurrent.CompletableFuture
 
@@ -34,7 +35,7 @@ interface AsyncView<K : Any, I : Any> {
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
-  ): ResultWithCapacityConsumed<I?> = loadAsyncWithConsumedCapacity(key, consistentReads, returnConsumedCapacity).await()
+  ): Pair<I?, ConsumedCapacity> = loadAsyncWithConsumedCapacity(key, consistentReads, returnConsumedCapacity).await()
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear
@@ -79,7 +80,7 @@ interface AsyncView<K : Any, I : Any> {
     key: K,
     consistentReads: Boolean,
     returnConsumedCapacity: ReturnConsumedCapacity
-  ): CompletableFuture<ResultWithCapacityConsumed<I?>>
+  ): CompletableFuture<Pair<I?, ConsumedCapacity>>
 
   fun loadAsync(key: K) = loadAsync(key, false)
 

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
@@ -31,11 +31,11 @@ interface AsyncView<K : Any, I : Any> {
    */
   suspend fun load(key: K, consistentReads: Boolean = false): I? = loadAsync(key, consistentReads).await()
 
-  suspend fun loadWithConsumedCapacity(
+  suspend fun load(
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
-  ): Pair<I?, ConsumedCapacity?> = loadAsyncWithConsumedCapacity(key, consistentReads, returnConsumedCapacity).await()
+  ): Pair<I?, ConsumedCapacity?> = loadAsync(key, consistentReads, returnConsumedCapacity).await()
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear
@@ -76,7 +76,7 @@ interface AsyncView<K : Any, I : Any> {
 
   fun loadAsync(key: K, consistentReads: Boolean): CompletableFuture<I?>
 
-  fun loadAsyncWithConsumedCapacity(
+  fun loadAsync(
     key: K,
     consistentReads: Boolean,
     returnConsumedCapacity: ReturnConsumedCapacity

--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
@@ -30,7 +30,11 @@ interface AsyncView<K : Any, I : Any> {
    */
   suspend fun load(key: K, consistentReads: Boolean = false): I? = loadAsync(key, consistentReads).await()
 
-  suspend fun loadWithCapacity(key: K, consistentReads: Boolean = false, returnConsumedCapacity: ReturnConsumedCapacity): ResultWithCapacityConsumed<I?> = loadAsyncWithCapacity(key, consistentReads, returnConsumedCapacity).await()
+  suspend fun loadWithConsumedCapacity(
+    key: K,
+    consistentReads: Boolean = false,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
+  ): ResultWithCapacityConsumed<I?> = loadAsyncWithConsumedCapacity(key, consistentReads, returnConsumedCapacity).await()
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear
@@ -70,7 +74,12 @@ interface AsyncView<K : Any, I : Any> {
   // Overloaded functions for Java callers (Kotlin interfaces do not support `@JvmOverloads`).
 
   fun loadAsync(key: K, consistentReads: Boolean): CompletableFuture<I?>
-  fun loadAsyncWithCapacity(key: K, consistentReads: Boolean, returnConsumedCapacity: ReturnConsumedCapacity): CompletableFuture<ResultWithCapacityConsumed<I?>>
+
+  fun loadAsyncWithConsumedCapacity(
+    key: K,
+    consistentReads: Boolean,
+    returnConsumedCapacity: ReturnConsumedCapacity
+  ): CompletableFuture<ResultWithCapacityConsumed<I?>>
 
   fun loadAsync(key: K) = loadAsync(key, false)
 

--- a/tempest2/src/main/kotlin/app/cash/tempest2/LogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/LogicalDb.kt
@@ -58,48 +58,26 @@ interface LogicalDb : LogicalTable.Factory {
   fun batchLoad(
     keys: KeySet,
     consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ
+    maxPageSize: Int = MAX_BATCH_READ,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
   ): ItemSet
 
   fun batchLoad(
     keys: Iterable<Any>,
     consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ
+    maxPageSize: Int = MAX_BATCH_READ,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
   ): ItemSet {
-    return batchLoad(KeySet(keys), consistentReads, maxPageSize)
+    return batchLoad(KeySet(keys), consistentReads, maxPageSize, returnConsumedCapacity)
   }
 
   fun batchLoad(
     vararg keys: Any,
     consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ
+    maxPageSize: Int = MAX_BATCH_READ,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.NONE
   ): ItemSet {
-    return batchLoad(keys.toList(), consistentReads, maxPageSize)
-  }
-
-  fun batchLoadWithCapacity(
-    keys: KeySet,
-    consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ,
-    returnConsumedCapacity: ReturnConsumedCapacity
-  ): ResultWithCapacityConsumed<ItemSet>
-
-  fun batchLoadWithCapacity(
-    keys: Iterable<Any>,
-    consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ,
-    returnConsumedCapacity: ReturnConsumedCapacity
-  ): ResultWithCapacityConsumed<ItemSet> {
-    return batchLoadWithCapacity(KeySet(keys), consistentReads, maxPageSize, returnConsumedCapacity)
-  }
-
-  fun batchLoadWithCapacity(
-    vararg keys: Any,
-    consistentReads: Boolean = false,
-    maxPageSize: Int = MAX_BATCH_READ,
-    returnConsumedCapacity: ReturnConsumedCapacity
-  ): ResultWithCapacityConsumed<ItemSet> {
-    return batchLoadWithCapacity(keys.toList(), consistentReads, maxPageSize, returnConsumedCapacity)
+    return batchLoad(keys.toList(), consistentReads, maxPageSize, returnConsumedCapacity)
   }
 
   /**

--- a/tempest2/src/main/kotlin/app/cash/tempest2/LogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/LogicalDb.kt
@@ -20,6 +20,7 @@ import app.cash.tempest2.internal.LogicalDbFactory
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
 import software.amazon.awssdk.enhanced.dynamodb.extensions.annotations.DynamoDbVersionAttribute
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import javax.annotation.CheckReturnValue
 import kotlin.reflect.KClass
 
@@ -76,7 +77,30 @@ interface LogicalDb : LogicalTable.Factory {
     return batchLoad(keys.toList(), consistentReads, maxPageSize)
   }
 
+  fun batchLoadWithCapacity(
+    keys: KeySet,
+    consistentReads: Boolean = false,
+    maxPageSize: Int = MAX_BATCH_READ,
+    returnConsumedCapacity: ReturnConsumedCapacity
+  ): ResultWithCapacityConsumed<ItemSet>
 
+  fun batchLoadWithCapacity(
+    keys: Iterable<Any>,
+    consistentReads: Boolean = false,
+    maxPageSize: Int = MAX_BATCH_READ,
+    returnConsumedCapacity: ReturnConsumedCapacity
+  ): ResultWithCapacityConsumed<ItemSet> {
+    return batchLoadWithCapacity(KeySet(keys), consistentReads, maxPageSize, returnConsumedCapacity)
+  }
+
+  fun batchLoadWithCapacity(
+    vararg keys: Any,
+    consistentReads: Boolean = false,
+    maxPageSize: Int = MAX_BATCH_READ,
+    returnConsumedCapacity: ReturnConsumedCapacity
+  ): ResultWithCapacityConsumed<ItemSet> {
+    return batchLoadWithCapacity(keys.toList(), consistentReads, maxPageSize, returnConsumedCapacity)
+  }
 
   /**
    * Saves and deletes the objects given using one or more calls to the

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
@@ -213,10 +213,11 @@ class KeySet private constructor(
  * A collection of items across tables.
  */
 class ItemSet private constructor(
-  private val contents: Set<Any>
+  private val contents: Set<Any>,
+  val consumedCapacity: List<ConsumedCapacity>
 ) : Set<Any> by contents {
 
-  constructor(contents: Iterable<Any>) : this(contents.toSet())
+  constructor(contents: Iterable<Any>, consumedCapacity: List<ConsumedCapacity> = emptyList()) : this(contents.toSet(), consumedCapacity)
 
   fun <I : Any> getItems(
     itemType: KClass<I>
@@ -241,7 +242,3 @@ data class ResultWithCapacityConsumed<T>(
   val results: T,
   val consumedCapacity: List<ConsumedCapacity>
 )
-
-inline fun <reified I : Any> ResultWithCapacityConsumed<ItemSet>.getItems(): List<I> {
-  return this.results.getItems()
-}

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
@@ -237,8 +237,3 @@ class ItemSet private constructor(
 
   override fun toString(): String = contents.toString()
 }
-
-data class ResultWithCapacityConsumed<T>(
-  val results: T,
-  val consumedCapacity: List<ConsumedCapacity>
-)

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Model.kt
@@ -18,6 +18,7 @@ package app.cash.tempest2
 
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
 import kotlin.reflect.KClass
 
 /**
@@ -234,4 +235,13 @@ class ItemSet private constructor(
   fun getAllItems(): Set<Any> = contents
 
   override fun toString(): String = contents.toString()
+}
+
+data class ResultWithCapacityConsumed<T>(
+  val results: T,
+  val consumedCapacity: List<ConsumedCapacity>
+)
+
+inline fun <reified I : Any> ResultWithCapacityConsumed<ItemSet>.getItems(): List<I> {
+  return this.results.getItems()
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/Paging.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/Paging.kt
@@ -16,9 +16,12 @@
 
 package app.cash.tempest2
 
+import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
+
 data class Page<K, T> internal constructor(
   val contents: List<T>,
-  val offset: Offset<K>?
+  val offset: Offset<K>?,
+  val consumedCapacity: ConsumedCapacity?
 ) {
   val hasMorePages: Boolean
     get() = offset != null

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -33,7 +33,7 @@ interface View<K : Any, I : Any> {
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
-  ): Pair<I?, ConsumedCapacity>
+  ): Pair<I?, ConsumedCapacity?>
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -29,7 +29,7 @@ interface View<K : Any, I : Any> {
    */
   fun load(key: K, consistentReads: Boolean = false): I?
 
-  fun loadWithConsumedCapacity(
+  fun load(
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -19,6 +19,7 @@ package app.cash.tempest2
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 
 interface View<K : Any, I : Any> {
@@ -32,7 +33,7 @@ interface View<K : Any, I : Any> {
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
-  ): ResultWithCapacityConsumed<I?>
+  ): Pair<I?, ConsumedCapacity>
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -27,7 +27,12 @@ interface View<K : Any, I : Any> {
    * such item exists.
    */
   fun load(key: K, consistentReads: Boolean = false): I?
-  fun loadWithCapacity(key: K, consistentReads: Boolean = false, returnConsumedCapacity: ReturnConsumedCapacity): ResultWithCapacityConsumed<I?>
+
+  fun loadWithCapacity(
+    key: K,
+    consistentReads: Boolean = false,
+    returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL
+  ): ResultWithCapacityConsumed<I?>
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -19,6 +19,7 @@ package app.cash.tempest2
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtension
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 
 interface View<K : Any, I : Any> {
   /**
@@ -26,6 +27,7 @@ interface View<K : Any, I : Any> {
    * such item exists.
    */
   fun load(key: K, consistentReads: Boolean = false): I?
+  fun loadWithCapacity(key: K, consistentReads: Boolean = false, returnConsumedCapacity: ReturnConsumedCapacity): ResultWithCapacityConsumed<I?>
 
   /**
    * Saves an item in DynamoDB. This method uses [DynamoDbClient.putItem] to clear

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -28,7 +28,7 @@ interface View<K : Any, I : Any> {
    */
   fun load(key: K, consistentReads: Boolean = false): I?
 
-  fun loadWithCapacity(
+  fun loadWithConsumedCapacity(
     key: K,
     consistentReads: Boolean = false,
     returnConsumedCapacity: ReturnConsumedCapacity = ReturnConsumedCapacity.TOTAL

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -26,11 +26,9 @@ import app.cash.tempest2.ItemSet
 import app.cash.tempest2.KeySet
 import app.cash.tempest2.LogicalDb
 import app.cash.tempest2.LogicalTable
-import app.cash.tempest2.ResultWithCapacityConsumed
 import app.cash.tempest2.TransactionWriteSet
 import app.cash.tempest2.internal.DynamoDbLogicalDb.WriteRequest.Op.CLOBBER
 import app.cash.tempest2.internal.DynamoDbLogicalDb.WriteRequest.Op.DELETE
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.reactive.asFlow

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbScannable.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbScannable.kt
@@ -110,7 +110,7 @@ internal class DynamoDbScannable<K : Any, I : Any, R : Any>(
   private fun toScanResponse(page: software.amazon.awssdk.enhanced.dynamodb.model.Page<R>): Page<K, I> {
     val contents = page.items().map { itemCodec.toApp(it) }
     val offset = page.lastEvaluatedKey()?.decodeOffset()
-    return Page(contents, offset)
+    return Page(contents, offset, page.consumedCapacity())
   }
 
   private fun Offset<K>.encodeOffset(): Map<String, AttributeValue> {

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
@@ -18,6 +18,7 @@ package app.cash.tempest2.internal
 
 import app.cash.tempest.internal.Codec
 import app.cash.tempest2.AsyncView
+import app.cash.tempest2.ResultWithCapacityConsumed
 import app.cash.tempest2.View
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable
@@ -29,6 +30,7 @@ import software.amazon.awssdk.enhanced.dynamodb.internal.EnhancedClientUtils
 import software.amazon.awssdk.enhanced.dynamodb.model.DeleteItemEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import java.util.concurrent.CompletableFuture
 
 internal class DynamoDbView<K : Any, I : Any, R : Any>(
@@ -48,6 +50,17 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       return toLoadResponse(itemObject)
     }
 
+    override fun loadWithCapacity(
+      key: K,
+      consistentReads: Boolean,
+      returnConsumedCapacity: ReturnConsumedCapacity
+    ): ResultWithCapacityConsumed<I?> {
+      val request = toLoadRequest(key, consistentReads, returnConsumedCapacity)
+      val response = dynamoDbTable.getItemWithResponse(request)
+      val item = toLoadResponse(response.attributes())
+      return ResultWithCapacityConsumed(item, listOf(response.consumedCapacity()))
+    }
+
     override fun save(
       item: I,
       saveExpression: Expression?
@@ -62,7 +75,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
     ): I? {
       val request = toDeleteKeyRequest(key, deleteExpression)
       val itemObject = dynamoDbTable.deleteItem(request)
-      return toDeleteResponse(itemObject)
+      return toItem(itemObject)
     }
 
     override fun delete(
@@ -71,7 +84,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
     ): I? {
       val request = toDeleteItemRequest(item, deleteExpression)
       val itemObject = dynamoDbTable.deleteItem(request)
-      return toDeleteResponse(itemObject)
+      return toItem(itemObject)
     }
   }
 
@@ -82,7 +95,20 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
   ) : AsyncView<K, I> {
     override fun loadAsync(key: K, consistentReads: Boolean): CompletableFuture<I?> {
       val request = toLoadRequest(key, consistentReads)
-      return dynamoDbTable.getItem(request).thenApply(::toDeleteResponse)
+      return dynamoDbTable.getItem(request).thenApply(::toItem)
+    }
+
+    override fun loadAsyncWithCapacity(
+      key: K,
+      consistentReads: Boolean,
+      returnConsumedCapacity: ReturnConsumedCapacity
+    ): CompletableFuture<ResultWithCapacityConsumed<I?>> {
+      val request = toLoadRequest(key, consistentReads, returnConsumedCapacity)
+      return dynamoDbTable.getItemWithResponse(request)
+        .thenApply { response ->
+          val item = toItem(response.attributes())
+          ResultWithCapacityConsumed(item, listOf(response.consumedCapacity()))
+        }
     }
 
     override fun saveAsync(
@@ -98,7 +124,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       deleteExpression: Expression?
     ): CompletableFuture<I?> {
       val request = toDeleteKeyRequest(key, deleteExpression)
-      return dynamoDbTable.deleteItem(request).thenApply(::toDeleteResponse)
+      return dynamoDbTable.deleteItem(request).thenApply(::toItem)
     }
 
     override fun deleteAsync(
@@ -106,7 +132,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       deleteExpression: Expression?
     ): CompletableFuture<I?> {
       val request = toDeleteItemRequest(item, deleteExpression)
-      return dynamoDbTable.deleteItem(request).thenApply(::toDeleteResponse)
+      return dynamoDbTable.deleteItem(request).thenApply(::toItem)
     }
   }
 
@@ -117,11 +143,12 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
     )
   }
 
-  private fun toLoadRequest(key: K, consistentReads: Boolean): GetItemEnhancedRequest {
+  private fun toLoadRequest(key: K, consistentReads: Boolean, returnConsumedCapacity: ReturnConsumedCapacity? = null): GetItemEnhancedRequest {
     val keyObject = keyCodec.toDb(key)
     return GetItemEnhancedRequest.builder()
       .key(keyObject.key())
       .consistentRead(consistentReads)
+      .returnConsumedCapacity(returnConsumedCapacity)
       .build()
   }
 
@@ -151,5 +178,5 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       .build()
   }
 
-  private fun toDeleteResponse(itemObject: R?) = if (itemObject != null) itemCodec.toApp(itemObject) else null
+  private fun toItem(itemObject: R?) = if (itemObject != null) itemCodec.toApp(itemObject) else null
 }

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
@@ -50,7 +50,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       return toLoadResponse(itemObject)
     }
 
-    override fun loadWithCapacity(
+    override fun loadWithConsumedCapacity(
       key: K,
       consistentReads: Boolean,
       returnConsumedCapacity: ReturnConsumedCapacity
@@ -98,7 +98,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       return dynamoDbTable.getItem(request).thenApply(::toItem)
     }
 
-    override fun loadAsyncWithCapacity(
+    override fun loadAsyncWithConsumedCapacity(
       key: K,
       consistentReads: Boolean,
       returnConsumedCapacity: ReturnConsumedCapacity

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
@@ -50,7 +50,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       return toLoadResponse(itemObject)
     }
 
-    override fun loadWithConsumedCapacity(
+    override fun load(
       key: K,
       consistentReads: Boolean,
       returnConsumedCapacity: ReturnConsumedCapacity
@@ -98,7 +98,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       return dynamoDbTable.getItem(request).thenApply(::toItem)
     }
 
-    override fun loadAsyncWithConsumedCapacity(
+    override fun loadAsync(
       key: K,
       consistentReads: Boolean,
       returnConsumedCapacity: ReturnConsumedCapacity

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
@@ -54,7 +54,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       key: K,
       consistentReads: Boolean,
       returnConsumedCapacity: ReturnConsumedCapacity
-    ): Pair<I?, ConsumedCapacity> {
+    ): Pair<I?, ConsumedCapacity?> {
       val request = toLoadRequest(key, consistentReads, returnConsumedCapacity)
       val response = dynamoDbTable.getItemWithResponse(request)
       val item = toLoadResponse(response.attributes())
@@ -102,7 +102,7 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
       key: K,
       consistentReads: Boolean,
       returnConsumedCapacity: ReturnConsumedCapacity
-    ): CompletableFuture<Pair<I?, ConsumedCapacity>> {
+    ): CompletableFuture<Pair<I?, ConsumedCapacity?>> {
       val request = toLoadRequest(key, consistentReads, returnConsumedCapacity)
       return dynamoDbTable.getItemWithResponse(request)
         .thenApply { response ->

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/UnsupportedAsyncQueryable.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/UnsupportedAsyncQueryable.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.reactive.asPublisher
 import org.reactivestreams.Publisher
 import software.amazon.awssdk.enhanced.dynamodb.Expression
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import kotlin.reflect.KClass
 
 internal class UnsupportedAsyncQueryable<K : Any, I : Any>(
@@ -35,7 +36,8 @@ internal class UnsupportedAsyncQueryable<K : Any, I : Any>(
     pageSize: Int,
     consistentRead: Boolean,
     filterExpression: Expression?,
-    initialOffset: Offset<K>?
+    initialOffset: Offset<K>?,
+    returnConsumedCapacity: ReturnConsumedCapacity?
   ): Publisher<Page<K, I>> {
     return flow<Page<K, I>> {
       throw UnsupportedOperationException("Require $rawType to have a range key. You can query a table or an index only if it has a composite primary key (partition key and sort key)")

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/UnsupportedQueryable.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/UnsupportedQueryable.kt
@@ -21,6 +21,7 @@ import app.cash.tempest2.Offset
 import app.cash.tempest2.Page
 import app.cash.tempest2.Queryable
 import software.amazon.awssdk.enhanced.dynamodb.Expression
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import java.lang.UnsupportedOperationException
 import kotlin.reflect.KClass
 
@@ -33,7 +34,8 @@ internal class UnsupportedQueryable<K : Any, I : Any>(
     pageSize: Int,
     consistentRead: Boolean,
     filterExpression: Expression?,
-    initialOffset: Offset<K>?
+    initialOffset: Offset<K>?,
+    returnConsumedCapacity: ReturnConsumedCapacity?
   ): Page<K, I> {
     throw UnsupportedOperationException("Require $rawType to have a range key. You can query a table or an index only if it has a composite primary key (partition key and sort key)")
   }

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
@@ -72,7 +72,7 @@ class DynamoDbAsyncViewTest {
     musicTable.albumInfo.save(albumInfo)
 
     // Query the movies created.
-    val (loadedAlbumInfo, consumedCapacity) = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
+    val (loadedAlbumInfo, consumedCapacity) = musicTable.albumInfo.load(albumInfo.key, returnConsumedCapacity = ReturnConsumedCapacity.TOTAL)
 
     assertThat(loadedAlbumInfo!!.album_token).isEqualTo(albumInfo.album_token)
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
@@ -80,7 +80,7 @@ class DynamoDbAsyncViewTest {
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
     assertThat(consumedCapacity?.capacityUnits()).isGreaterThan(0.0)
 
-    val (_, consumedCapacity2) = musicTable.albumInfo.loadWithConsumedCapacity(
+    val (_, consumedCapacity2) = musicTable.albumInfo.load(
       albumInfo.key,
       returnConsumedCapacity = ReturnConsumedCapacity.NONE
     )

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
@@ -60,6 +60,29 @@ class DynamoDbAsyncViewTest {
   }
 
   @Test
+  fun loadAfterSaveWithConsumedCapacity() = runBlockingTest {
+    val albumInfo = AlbumInfo(
+      "ALBUM_1",
+      "after hours - EP",
+      "53 Thieves",
+      LocalDate.of(2020, 2, 21),
+      "Contemporary R&B"
+    )
+    musicTable.albumInfo.save(albumInfo)
+
+    // Query the movies created.
+    val response = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
+
+    val loadedAlbumInfo = response.results!!
+    assertThat(loadedAlbumInfo.album_token).isEqualTo(albumInfo.album_token)
+    assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
+    assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
+    assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
+
+    assertThat(response.consumedCapacity.first().capacityUnits()).isGreaterThan(0.0)
+  }
+
+  @Test
   fun saveIfNotExist() = runBlockingTest {
     val albumInfo = AlbumInfo(
       "ALBUM_1",

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import java.time.LocalDate
 
 class DynamoDbAsyncViewTest {
@@ -71,15 +72,19 @@ class DynamoDbAsyncViewTest {
     musicTable.albumInfo.save(albumInfo)
 
     // Query the movies created.
-    val response = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
+    val (loadedAlbumInfo, consumedCapacity) = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
 
-    val loadedAlbumInfo = response.results!!
-    assertThat(loadedAlbumInfo.album_token).isEqualTo(albumInfo.album_token)
+    assertThat(loadedAlbumInfo!!.album_token).isEqualTo(albumInfo.album_token)
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
     assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
+    assertThat(consumedCapacity.capacityUnits()).isGreaterThan(0.0)
 
-    assertThat(response.consumedCapacity.first().capacityUnits()).isGreaterThan(0.0)
+    val (_, consumedCapacity2) = musicTable.albumInfo.loadWithConsumedCapacity(
+      albumInfo.key,
+      returnConsumedCapacity = ReturnConsumedCapacity.NONE
+    )
+    assertThat(consumedCapacity2.capacityUnits()).isEqualTo(0.0)
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
@@ -78,13 +78,13 @@ class DynamoDbAsyncViewTest {
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
     assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
-    assertThat(consumedCapacity.capacityUnits()).isGreaterThan(0.0)
+    assertThat(consumedCapacity?.capacityUnits()).isGreaterThan(0.0)
 
     val (_, consumedCapacity2) = musicTable.albumInfo.loadWithConsumedCapacity(
       albumInfo.key,
       returnConsumedCapacity = ReturnConsumedCapacity.NONE
     )
-    assertThat(consumedCapacity2.capacityUnits()).isEqualTo(0.0)
+    assertThat(consumedCapacity2).isNull()
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbQueryableTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbQueryableTest.kt
@@ -336,7 +336,7 @@ class DynamoDbQueryableTest {
   }
 
   @Test
-  fun consumedCapacity() {
+  fun `returns consumed capacity with the response`() {
     musicTable.givenAlbums(AFTER_HOURS_EP)
 
     val page1 = musicTable.albumTracks.query(
@@ -346,17 +346,17 @@ class DynamoDbQueryableTest {
     )
     assertThat(page1.hasMorePages).isTrue()
     assertThat(page1.trackTitles).containsAll(AFTER_HOURS_EP.trackTitles.slice(0..1))
-    assertThat(page1.consumedCapacity).isNotNull
+    assertThat(page1.consumedCapacity?.capacityUnits()).isGreaterThan(0.0)
 
     val page2 = musicTable.albumTracks.query(
       keyCondition = BeginsWith(AlbumTrack.Key(AFTER_HOURS_EP.album_token, "")),
       pageSize = 2,
       initialOffset = page1.offset,
-      returnConsumedCapacity = ReturnConsumedCapacity.TOTAL
+      returnConsumedCapacity = ReturnConsumedCapacity.NONE
     )
     assertThat(page2.hasMorePages).isTrue()
     assertThat(page2.trackTitles).containsAll(AFTER_HOURS_EP.trackTitles.slice(2..3))
-    assertThat(page2.consumedCapacity).isNotNull
+    assertThat(page2.consumedCapacity).isNull()
 
     val page3 = musicTable.albumTracks.query(
       keyCondition = BeginsWith(AlbumTrack.Key(AFTER_HOURS_EP.album_token, "")),
@@ -366,7 +366,7 @@ class DynamoDbQueryableTest {
     )
     assertThat(page3.hasMorePages).isFalse()
     assertThat(page3.trackTitles).containsAll(AFTER_HOURS_EP.trackTitles.slice(4..4))
-    assertThat(page3.consumedCapacity).isNotNull
+    assertThat(page1.consumedCapacity?.capacityUnits()).isGreaterThan(0.0)
   }
 
   private fun runLengthLongerThan(duration: Duration): Expression {

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
@@ -78,13 +78,13 @@ class DynamoDbViewTest {
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
     assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
-    assertThat(consumedCapacity.capacityUnits()).isGreaterThan(0.0)
+    assertThat(consumedCapacity?.capacityUnits()).isGreaterThan(0.0)
 
     val (_, consumedCapacity2) = musicTable.albumInfo.loadWithConsumedCapacity(
       albumInfo.key,
       returnConsumedCapacity = ReturnConsumedCapacity.NONE
     )
-    assertThat(consumedCapacity2.capacityUnits()).isEqualTo(0.0)
+    assertThat(consumedCapacity2).isNull()
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
@@ -72,7 +72,7 @@ class DynamoDbViewTest {
     musicTable.albumInfo.save(albumInfo)
 
     // Query the movies created.
-    val response = musicTable.albumInfo.loadWithCapacity(albumInfo.key, returnConsumedCapacity = ReturnConsumedCapacity.TOTAL)
+    val response = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
 
     val loadedAlbumInfo = response.results!!
     assertThat(loadedAlbumInfo.album_token).isEqualTo(albumInfo.album_token)
@@ -80,7 +80,7 @@ class DynamoDbViewTest {
     assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
 
-    assertThat(response.consumedCapacity).isNotEmpty
+    assertThat(response.consumedCapacity.first().capacityUnits()).isGreaterThan(0.0)
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
+import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
 import java.time.LocalDate
 
 class DynamoDbViewTest {
@@ -57,6 +58,29 @@ class DynamoDbViewTest {
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
     assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
+  }
+
+  @Test
+  fun loadWithCapacityAfterSave() {
+    val albumInfo = AlbumInfo(
+      "ALBUM_1",
+      "after hours - EP",
+      "53 Thieves",
+      LocalDate.of(2020, 2, 21),
+      "Contemporary R&B"
+    )
+    musicTable.albumInfo.save(albumInfo)
+
+    // Query the movies created.
+    val response = musicTable.albumInfo.loadWithCapacity(albumInfo.key, returnConsumedCapacity = ReturnConsumedCapacity.TOTAL)
+
+    val loadedAlbumInfo = response.results!!
+    assertThat(loadedAlbumInfo.album_token).isEqualTo(albumInfo.album_token)
+    assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
+    assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
+    assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
+
+    assertThat(response.consumedCapacity).isNotEmpty
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
@@ -72,15 +72,19 @@ class DynamoDbViewTest {
     musicTable.albumInfo.save(albumInfo)
 
     // Query the movies created.
-    val response = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
+    val (loadedAlbumInfo, consumedCapacity) = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
 
-    val loadedAlbumInfo = response.results!!
-    assertThat(loadedAlbumInfo.album_token).isEqualTo(albumInfo.album_token)
+    assertThat(loadedAlbumInfo!!.album_token).isEqualTo(albumInfo.album_token)
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
     assertThat(loadedAlbumInfo.release_date).isEqualTo(albumInfo.release_date)
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
+    assertThat(consumedCapacity.capacityUnits()).isGreaterThan(0.0)
 
-    assertThat(response.consumedCapacity.first().capacityUnits()).isGreaterThan(0.0)
+    val (_, consumedCapacity2) = musicTable.albumInfo.loadWithConsumedCapacity(
+      albumInfo.key,
+      returnConsumedCapacity = ReturnConsumedCapacity.NONE
+    )
+    assertThat(consumedCapacity2.capacityUnits()).isEqualTo(0.0)
   }
 
   @Test

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbViewTest.kt
@@ -72,7 +72,7 @@ class DynamoDbViewTest {
     musicTable.albumInfo.save(albumInfo)
 
     // Query the movies created.
-    val (loadedAlbumInfo, consumedCapacity) = musicTable.albumInfo.loadWithConsumedCapacity(albumInfo.key)
+    val (loadedAlbumInfo, consumedCapacity) = musicTable.albumInfo.load(albumInfo.key, returnConsumedCapacity = ReturnConsumedCapacity.TOTAL)
 
     assertThat(loadedAlbumInfo!!.album_token).isEqualTo(albumInfo.album_token)
     assertThat(loadedAlbumInfo.artist_name).isEqualTo(albumInfo.artist_name)
@@ -80,7 +80,7 @@ class DynamoDbViewTest {
     assertThat(loadedAlbumInfo.genre_name).isEqualTo(albumInfo.genre_name)
     assertThat(consumedCapacity?.capacityUnits()).isGreaterThan(0.0)
 
-    val (_, consumedCapacity2) = musicTable.albumInfo.loadWithConsumedCapacity(
+    val (_, consumedCapacity2) = musicTable.albumInfo.load(
       albumInfo.key,
       returnConsumedCapacity = ReturnConsumedCapacity.NONE
     )

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -179,7 +179,7 @@ class LogicalDbBatchTest {
     )
     musicTable.playlistInfo.save(playlistInfo)
 
-    val loadedItems = musicDb.batchLoadWithCapacity(
+    val loadedItems = musicDb.batchLoad(
       PlaylistInfo.Key("PLAYLIST_1"),
       *(albumTracks.map { AlbumTrack.Key("ALBUM_1", track_number = it.track_number) }.toTypedArray()),
       returnConsumedCapacity = ReturnConsumedCapacity.TOTAL

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -186,6 +186,16 @@ class LogicalDbBatchTest {
     )
     assertThat(loadedItems.getItems<AlbumTrack>()).containsAll(albumTracks)
     assertThat(loadedItems.getItems<PlaylistInfo>()).containsExactly(playlistInfo)
-    assertThat(loadedItems.consumedCapacity).isNotEmpty
+
+    assertThat(loadedItems.consumedCapacity)
+      .extracting<Double> { it.capacityUnits() }
+      .contains(50.0, 3.0)
+
+    val loadedWithoutCapacity = musicDb.batchLoad(
+      PlaylistInfo.Key("PLAYLIST_1"),
+      *(albumTracks.map { AlbumTrack.Key("ALBUM_1", track_number = it.track_number) }.toTypedArray()),
+      returnConsumedCapacity = ReturnConsumedCapacity.NONE
+    )
+    assertThat(loadedWithoutCapacity.consumedCapacity).isEmpty()
   }
 }


### PR DESCRIPTION
This was not possible with the old version of the enhanced client and was recently added. This will allow us to optionally get data on the consumed capacity for each of these calls and make informed decisions on design viability.