### PR TITLE
rollback to 1.8.22

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  kotlin("jvm") version "1.9.23"
+  kotlin("jvm") version "1.8.22"
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 ktlint = "0.40.0"
-kotlin = "1.9.23"
+kotlin = "1.8.22"
 
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }


### PR DESCRIPTION
Hoping to address [these build failures](https://github.com/cashapp/tempest/actions/runs/8382466494/job/22988277714), without returning the 1.7.0 which caused [this issue](https://github.com/cashapp/tempest/issues/171)