### PR TITLE
bugfix: Consume all result pages in DynamoDbLogicalDb.batchLoad

### DIFF
--- a/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicItem.kt
+++ b/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicItem.kt
@@ -54,6 +54,7 @@ class MusicItem {
   var track_title: String? = null
   @get:DynamoDbConvertedBy(DurationTypeConverter::class)
   var run_length: Duration? = null
+  var track_description: String? = null
 
   // PlaylistInfo.
   var playlist_name: String? = null

--- a/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicTable.kt
+++ b/samples/musiclibrary2/src/main/kotlin/app/cash/tempest2/musiclibrary/MusicTable.kt
@@ -94,14 +94,16 @@ data class AlbumTrack(
   @Attribute(name = "sort_key", prefix = "TRACK_")
   val track_token: String,
   val track_title: String,
-  val run_length: Duration
+  val run_length: Duration,
+  val track_description: String = "",
 ) {
   constructor(
     album_token: String,
     track_number: Long,
     track_title: String,
-    run_length: Duration
-  ) : this(album_token, "%016x".format(track_number), track_title, run_length)
+    run_length: Duration,
+    track_description: String = "",
+  ) : this(album_token, "%016x".format(track_number), track_title, run_length, track_description)
 
   @Transient
   val key = Key(album_token, track_token)

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -101,8 +101,8 @@ internal class DynamoDbLogicalDb(
         returnConsumedCapacity
       )
 
-      val pages = batchRequests.map {
-        dynamoDbEnhancedClient.batchGetItem(it).iterator().next()
+      val pages = batchRequests.flatMap {
+        dynamoDbEnhancedClient.batchGetItem(it).iterator().asSequence().toList()
       }
 
       return toBatchLoadResponse(keysByTable, requestKeys, pages)

--- a/tempest2/src/test/kotlin/app/cash/tempest2/AsyncLogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/AsyncLogicalDbBatchTest.kt
@@ -23,7 +23,6 @@ import app.cash.tempest2.musiclibrary.testDb
 import app.cash.tempest2.testing.asyncLogicalDb
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Duration
 

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -113,7 +113,7 @@ class LogicalDbBatchTest {
 
     val loadedItems = musicDb.batchLoad(
       PlaylistInfo.Key("PLAYLIST_1"),
-      albumTracks.map { AlbumTrack.Key("ALBUM_1", track_number = it.track_number) }
+      *(albumTracks.map { AlbumTrack.Key("ALBUM_1", track_number = it.track_number) }.toTypedArray())
     )
     assertThat(loadedItems.getItems<AlbumTrack>()).containsExactlyInAnyOrderElementsOf(albumTracks)
     assertThat(loadedItems.getItems<PlaylistInfo>()).containsExactly(playlistInfo)

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -88,12 +88,18 @@ class LogicalDbBatchTest {
 
   @Test
   fun `batchLoad more than 16MB`() = runBlockingTest {
-    val threeHundredKbName = "a".repeat(300_000)
+    val threeHundredKbDescription = "a".repeat(300_000)
 
     // Generate ~30MB of data. Dynamo only supports reading 16MB per batch request, so we need to handled retries to
     // get the second page of data
     val albumTracks = (1 until (MAX_BATCH_READ)).map {
-      AlbumTrack("ALBUM_1", it.toLong(), threeHundredKbName, Duration.parse("PT3M28S"))
+      AlbumTrack(
+        "ALBUM_1",
+        it.toLong(),
+        "track $it",
+        Duration.parse("PT3M28S"),
+        threeHundredKbDescription,
+      )
     }
     for (albumTrack in albumTracks) {
       musicTable.albumTracks.save(albumTrack)

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -88,9 +88,9 @@ class LogicalDbBatchTest {
 
   @Test
   fun `batchLoad more than 16MB`() = runBlockingTest {
-    val threeHundredKbDescription = "a".repeat(300_000)
+    val twoHundredKbDescription = "a".repeat(200_000)
 
-    // Generate ~30MB of data. Dynamo only supports reading 16MB per batch request, so we need to handled retries to
+    // Generate ~20MB of data. Dynamo only supports reading 16MB per batch request, so we need to handled retries to
     // get the second page of data
     val albumTracks = (1 until (MAX_BATCH_READ)).map {
       AlbumTrack(
@@ -98,7 +98,7 @@ class LogicalDbBatchTest {
         it.toLong(),
         "track $it",
         Duration.parse("PT3M28S"),
-        threeHundredKbDescription,
+        twoHundredKbDescription,
       )
     }
     for (albumTrack in albumTracks) {

--- a/tempest2/src/test/kotlin/app/cash/tempest2/WritingPagerTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/WritingPagerTest.kt
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException
-import java.util.function.BiFunction
-import kotlin.streams.toList
 
 class WritingPagerTest {
 

--- a/tempest2/src/test/kotlin/app/cash/tempest2/internal/SchemaTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/internal/SchemaTest.kt
@@ -86,7 +86,7 @@ class SchemaTest {
 
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.inlineView(Any::class, BadItem5::class)
-    }.withMessage("Expect nonexistent_attribute, required by class app.cash.tempest2.internal.BadItem5, to be declared in class app.cash.tempest2.musiclibrary.MusicItem. But found [album_title, artist_name, genre_name, label_name, partition_key, playlist_name, playlist_size, playlist_tracks, playlist_version, release_date, run_length, sort_key, track_title, track_token]. Use @Transient to exclude it. You might see this error message if the property name starts with `is`. See: https://github.com/cashapp/tempest/issues/53.")
+    }.withMessage("Expect nonexistent_attribute, required by class app.cash.tempest2.internal.BadItem5, to be declared in class app.cash.tempest2.musiclibrary.MusicItem. But found [album_title, artist_name, genre_name, label_name, partition_key, playlist_name, playlist_size, playlist_tracks, playlist_version, release_date, run_length, sort_key, track_description, track_title, track_token]. Use @Transient to exclude it. You might see this error message if the property name starts with `is`. See: https://github.com/cashapp/tempest/issues/53.")
 
     assertThatIllegalArgumentException().isThrownBy {
       musicDb.music.inlineView(Any::class, BadItem6::class)


### PR DESCRIPTION
This fixes a somewhat subtle bug I realized `tempest2` has.

From the [enhanced client docs](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/enhanced/dynamodb/DynamoDbEnhancedClient.html#batchGetItem(software.amazon.awssdk.enhanced.dynamodb.model.BatchGetItemEnhancedRequest)) (emphasis mine): 
> Partial results. A single call to DynamoDb has restraints on how much data can be retrieved. If those limits are exceeded, the call yields a partial result. This may also be the case if provisional throughput is exceeded or there is an internal DynamoDb processing failure. The operation automatically retries any unprocessed keys returned from DynamoDb **in subsequent calls for pages**.

Tempest currently only gets the first page of results.

From the [BatchGetItem](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchGetItem.html) docs, the reasons that partial results can be returned are:
> the response size limit is exceeded, the table's provisioned throughput is exceeded, more than 1MB per partition is requested, or an internal processing failure occurs.

The end result is that tempest silently drops some results from `batchLoad` when these conditions occur because it only consumes the first page of the iterator.

This might also happen in `DynamoDbQueryable` and `DynamoDbScannable` as they also only consume the first page of the iterator - I haven't done enough digging there to confirm.

Seemingly this isn't the case with `tempest`, as the mapper it uses handles `unprocessedKeys` under the hood