### PR TITLE
Bump to Java 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,14 +72,14 @@ subprojects {
   plugins.withType<KotlinPluginWrapper> {
     tasks.withType<KotlinCompile> {
       kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_1_11.toString()
       }
       // dependsOn("spotlessKotlinApply")
     }
 
     tasks.withType<JavaCompile> {
-      sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-      targetCompatibility = JavaVersion.VERSION_1_8.toString()
+      sourceCompatibility = JavaVersion.VERSION_1_11.toString()
+      targetCompatibility = JavaVersion.VERSION_1_11.toString()
     }
 
     dependencies {
@@ -107,7 +107,7 @@ subprojects {
       dokkaSourceSets.configureEach {
         reportUndocumented.set(false)
         skipDeprecated.set(true)
-        jdkVersion.set(8)
+        jdkVersion.set(11)
 
         externalDocumentationLink {
           url.set(URL("https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/"))


### PR DESCRIPTION
Unfortunately bumping the kotlin version didn't resolve https://github.com/cashapp/tempest/issues/171 for us. We've been developing against a temporary private fork to stay unblocked (read: a copy/pasted monstrosity), but I'd like to get it cleaned up.

I'm hoping that means that the JVM version mismatch is the issue, since we're on Java 21. Since this is the same JVM version used in Misk, I figure it's ok to bump to. Honestly though, this is a shot in the dark. I've got no idea what's causing these issues

I've made a few attempts to downgrade the JVM version on my end for testing purposes, but it ends up in dependency hell really quickly so this seemed like the easiest next step.

Let me know if there's a specific reason tempest uses 1.8