### PR TITLE
Set -Xjvm-default=all compiler arg

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ subprojects {
     tasks.withType<KotlinCompile> {
       kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.toString()
-        freeCompilerArgs = listOf("-Xjvm-default=all")
+        freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
       }
       // dependsOn("spotlessKotlinApply")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ subprojects {
     tasks.withType<KotlinCompile> {
       kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.toString()
+        freeCompilerArgs = listOf("-Xjvm-default=all")
       }
       // dependsOn("spotlessKotlinApply")
     }


### PR DESCRIPTION
Finally cracked https://github.com/cashapp/tempest/issues/171. It turns out the issue _is_ kotlin related.

The root of the problem was that our project has the `-Xjvm-default=all` compiler flag set. Commenting it out eliminates this issue.

Seems like there's some subtle backwards incompatibility around annotations on pre-Java 8 interfaces with default implementations. Before Java 8, interfaces didn't support default implementations and would have a `DefaultImpls` static class declared to emulate that behaviour. Kotlin defaults to that pre-Java 8 behaviour ([docs](https://kotlinlang.org/docs/java-to-kotlin-interop.html#disable)), and generates DefaultImpl objects. It seems like tempest using the pre-java-8 style here causes in projects that enable the post-java 8 behaviour.

`all-compatibility` seems like the correct setting to be using here, based on [these docs](https://kotlinlang.org/docs/java-to-kotlin-interop.html#all-compatibility):
> In addition to the all mode, generate compatibility stubs in the [DefaultImpls](https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/) classes. Compatibility stubs could be useful for library and runtime authors to keep backward binary compatibility for existing clients compiled against previous library versions. all and all-compatibility modes are changing the library ABI surface that clients will use after the recompilation of the library. In that sense, clients might be incompatible with previous library versions. This usually means that you need a proper library versioning, for example, major version increase in SemVer.

Hopefully this will fix our side without breaking other use cases
