### PR TITLE
Add support for ReturnValuesOnConditionCheckFailure on views

### DIFF
--- a/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/AsyncView.kt
@@ -22,6 +22,7 @@ import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtens
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
+import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure
 import java.util.concurrent.CompletableFuture
 
 interface AsyncView<K : Any, I : Any> {
@@ -47,8 +48,14 @@ interface AsyncView<K : Any, I : Any> {
    */
   suspend fun save(
     item: I,
-    saveExpression: Expression? = null
-  ) = saveAsync(item, saveExpression).await()
+    saveExpression: Expression? = null,
+  ) = save(item, saveExpression, null)
+
+  suspend fun save(
+    item: I,
+    saveExpression: Expression? = null,
+    returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null
+  ) = saveAsync(item, saveExpression, returnValuesOnConditionCheckFailure).await()
 
   /**
    * Deletes the item identified by [key] from its DynamoDB table using [deleteExpression]. Any
@@ -86,12 +93,18 @@ interface AsyncView<K : Any, I : Any> {
 
   fun saveAsync(
     item: I,
-    saveExpression: Expression?
+    saveExpression: Expression?,
+    returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null
   ): CompletableFuture<Void>
 
   fun saveAsync(
     item: I
-  ) = saveAsync(item, saveExpression = null)
+  ) = saveAsync(item, saveExpression = null, returnValuesOnConditionCheckFailure = null)
+
+  fun saveAsync(
+    item: I,
+    saveExpression: Expression?
+  ) = saveAsync(item, saveExpression, returnValuesOnConditionCheckFailure = null)
 
   fun deleteKeyAsync(
     key: K,

--- a/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/View.kt
@@ -21,6 +21,7 @@ import software.amazon.awssdk.enhanced.dynamodb.extensions.VersionedRecordExtens
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
+import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure
 
 interface View<K : Any, I : Any> {
   /**
@@ -45,7 +46,8 @@ interface View<K : Any, I : Any> {
    */
   fun save(
     item: I,
-    saveExpression: Expression? = null
+    saveExpression: Expression? = null,
+    returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null
   )
 
   /**
@@ -76,7 +78,12 @@ interface View<K : Any, I : Any> {
 
   fun save(
     item: I
-  ) = save(item, saveExpression = null)
+  ) = save(item, saveExpression = null, returnValuesOnConditionCheckFailure = null)
+
+  fun save(
+    item: I,
+    saveExpression: Expression? = null
+  ) = save(item, saveExpression, returnValuesOnConditionCheckFailure = null)
 
   fun deleteKey(
     key: K

--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbView.kt
@@ -31,6 +31,7 @@ import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.PutItemEnhancedRequest
 import software.amazon.awssdk.services.dynamodb.model.ConsumedCapacity
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
+import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure
 import java.util.concurrent.CompletableFuture
 
 internal class DynamoDbView<K : Any, I : Any, R : Any>(
@@ -63,9 +64,10 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
 
     override fun save(
       item: I,
-      saveExpression: Expression?
+      saveExpression: Expression?,
+      returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure?
     ) {
-      val request = toSaveRequest(item, saveExpression)
+      val request = toSaveRequest(item, saveExpression, returnValuesOnConditionCheckFailure)
       dynamoDbTable.putItem(request)
     }
 
@@ -113,9 +115,10 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
 
     override fun saveAsync(
       item: I,
-      saveExpression: Expression?
+      saveExpression: Expression?,
+      returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure?
     ): CompletableFuture<Void> {
-      val request = toSaveRequest(item, saveExpression)
+      val request = toSaveRequest(item, saveExpression, returnValuesOnConditionCheckFailure)
       return dynamoDbTable.putItem(request)
     }
 
@@ -154,11 +157,16 @@ internal class DynamoDbView<K : Any, I : Any, R : Any>(
 
   private fun toLoadResponse(itemObject: R?) = if (itemObject != null) itemCodec.toApp(itemObject) else null
 
-  private fun toSaveRequest(item: I, saveExpression: Expression?): PutItemEnhancedRequest<R> {
+  private fun toSaveRequest(
+    item: I,
+    saveExpression: Expression?,
+    returnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure?
+  ): PutItemEnhancedRequest<R> {
     val itemObject = itemCodec.toDb(item)
     return PutItemEnhancedRequest.builder(tableSchema.itemType().rawClass())
       .item(itemObject)
       .conditionExpression(saveExpression)
+      .returnValuesOnConditionCheckFailure(returnValuesOnConditionCheckFailure)
       .build()
   }
 

--- a/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/DynamoDbAsyncViewTest.kt
@@ -30,6 +30,7 @@ import software.amazon.awssdk.enhanced.dynamodb.Expression
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 import software.amazon.awssdk.services.dynamodb.model.ReturnConsumedCapacity
+import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure
 import java.time.LocalDate
 
 class DynamoDbAsyncViewTest {
@@ -96,7 +97,7 @@ class DynamoDbAsyncViewTest {
       LocalDate.of(2020, 2, 21),
       "Contemporary R&B"
     )
-    musicTable.albumInfo.save(albumInfo, ifNotExist())
+    musicTable.albumInfo.save(albumInfo, ifNotExist(), ReturnValuesOnConditionCheckFailure.ALL_OLD)
 
     // This fails because the album info already exists.
     assertThatExceptionOfType(ConditionalCheckFailedException::class.java)


### PR DESCRIPTION
This adds support for the ReturnValuesOnConditionCheckFailure parameter on saving items on views. This is helpful when you encounter a conditional check failure and don't want to do a read in order to get the correct version, etc.

This is still a WIP and needs a bunch of work to be complete.