### PR TITLE
Handle unprocessed deletes without throwing an IllegalArgumentException

### DIFF
--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -303,10 +303,8 @@ internal class DynamoDbLogicalDb(
       for (rawItem in rawClobbersItems) {
         unprocessedClobbers.add(rawItem.rawItemKey().key)
       }
-      val rawDeleteItems = results.flatMap { it.unprocessedDeleteItemsForTable(table) }
-      for (rawItem in rawDeleteItems) {
-        unprocessedDeletes.add(rawItem.rawItemKey().key)
-      }
+      val unprocessedDeletesForTable = results.flatMap { it.unprocessedDeleteItemsForTable(table) }.filterNotNull()
+      unprocessedDeletes.addAll(unprocessedDeletesForTable)
     }
 
     return app.cash.tempest2.BatchWriteResult(

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbFailueTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbFailueTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package app.cash.tempest2
+
+import app.cash.tempest2.musiclibrary.AlbumTrack
+import app.cash.tempest2.musiclibrary.MusicDb
+import app.cash.tempest2.musiclibrary.PlaylistInfo
+import app.cash.tempest2.musiclibrary.testDb
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.time.Duration
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
+import software.amazon.awssdk.enhanced.dynamodb.Key
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest
+import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult
+import software.amazon.awssdk.services.dynamodb.model.DeleteRequest
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest
+
+class LogicalDbFailueTest {
+
+  @RegisterExtension
+  @JvmField
+  val db = testDb()
+
+  // Fake client that prevents batch deletes from succeeding
+  class FakeDynamoDbEnhancedClient(private val realClient: DynamoDbEnhancedClient) :
+    DynamoDbEnhancedClient by realClient {
+    override fun batchWriteItem(request: BatchWriteItemEnhancedRequest?): BatchWriteResult {
+      val unprocessedDeletes = request!!.writeBatches().map { writeBatch ->
+        writeBatch.tableName() to writeBatch.writeRequests().map { writeRequest ->
+          val key = writeRequest.deleteRequest().key()
+          WriteRequest.builder()
+            .deleteRequest(
+              DeleteRequest.builder()
+                .key(key)
+                .build()
+            )
+            .build()
+        }
+      }
+
+      val results = unprocessedDeletes.associate { (tableName, keys) ->
+        tableName to keys
+      }
+      return BatchWriteResult.builder()
+        .unprocessedRequests(results)
+        .build()
+    }
+  }
+
+  private val musicDb by lazy {
+    val enhancedClient = DynamoDbEnhancedClient.builder()
+      .dynamoDbClient(db.dynamoDb)
+      .extensions(listOf())
+      .build()
+    val fakeEnhancedClient = FakeDynamoDbEnhancedClient(enhancedClient)
+    LogicalDb.create(MusicDb::class, fakeEnhancedClient)
+  }
+  private val musicTable by lazy { musicDb.music }
+
+  @Test
+  fun `batch write handles unprocessed deletes accurately`() {
+    val albumTracks = listOf(
+      AlbumTrack("ALBUM_1", 1, "dreamin'", Duration.parse("PT3M28S")),
+      AlbumTrack("ALBUM_1", 2, "what you do to me", Duration.parse("PT3M24S")),
+      AlbumTrack("ALBUM_1", 3, "too slow", Duration.parse("PT2M27S"))
+    )
+    for (albumTrack in albumTracks) {
+      musicTable.albumTracks.save(albumTrack)
+    }
+
+    val batchWriteResult = musicDb.batchWrite(
+      BatchWriteSet.Builder()
+        .delete(albumTracks.map { it.key })
+        .build()
+    )
+
+    assertThat(batchWriteResult.unprocessedDeletes.map { it.partitionKeyValue().s() to it.sortKeyValue().get().s() })
+      .containsExactlyInAnyOrderElementsOf(
+        albumTracks.map {
+          it.album_token to "TRACK_${it.track_token}"
+        }
+      )
+  }
+}

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbFailureTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbFailureTest.kt
@@ -18,20 +18,18 @@ package app.cash.tempest2
 
 import app.cash.tempest2.musiclibrary.AlbumTrack
 import app.cash.tempest2.musiclibrary.MusicDb
-import app.cash.tempest2.musiclibrary.PlaylistInfo
 import app.cash.tempest2.musiclibrary.testDb
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Duration
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient
-import software.amazon.awssdk.enhanced.dynamodb.Key
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteItemEnhancedRequest
 import software.amazon.awssdk.enhanced.dynamodb.model.BatchWriteResult
 import software.amazon.awssdk.services.dynamodb.model.DeleteRequest
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest
 
-class LogicalDbFailueTest {
+class LogicalDbFailureTest {
 
   @RegisterExtension
   @JvmField


### PR DESCRIPTION
I started running into exceptions that looked like the following:
```
java.lang.IllegalArgumentException: Cannot find a dynamodb table for class software.amazon.awssdk.enhanced.dynamodb.Key
	at app.cash.tempest2.internal.DynamoDbLogicalDb.expectedRawItemType(DynamoDbLogicalDb.kt:390)
	at app.cash.tempest2.internal.DynamoDbLogicalDb.rawItemKey(DynamoDbLogicalDb.kt:376)
	at app.cash.tempest2.internal.DynamoDbLogicalDb.toBatchWriteResponse(DynamoDbLogicalDb.kt:308)
	at app.cash.tempest2.internal.DynamoDbLogicalDb.access$toBatchWriteResponse(DynamoDbLogicalDb.kt:65)
	at app.cash.tempest2.internal.DynamoDbLogicalDb$Sync.batchWrite(DynamoDbLogicalDb.kt:120)
	at app.cash.tempest2.LogicalDb.batchWrite(LogicalDb.kt:125)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at app.cash.tempest.internal.ProxyFactory$invocationHandler$1.invoke(ProxyFactory.kt:55)
[skipping the private part of the stack trace]
```
`unprocessedDeleteItemsForTable` returns `Key`, but line 308 tries to call `rawItemKey()` on it and chokes. The net result is that tempest can't handle unprocessed deletes. Removing the unnecessary conversion should resolve it.

I couldn't see a way to verify that this would solve the problem, as there don't seem to be any tests around `unprocessedDeletes`. I tried a similar approach to my test [here](https://github.com/cashapp/tempest/blob/95a97b2f12a66477203e22239a874eebfcf3441b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt#L89-L120), but there's no way to delete more than 16MB. There's a max of 25 items, and each one can be 400KB. If each one is as big as possible, you only hit 10MB. Without mocking the dynamo client, there's no way to trigger a failure here.

The easiest way to test this is probably to expose the `toBatchWriteResponse` as an `internal` function and unit test it - there isn't an existing practice of that in this project so I was hesitant to do so. Let me know if you'd like a test added that follows that approach.