### PR TITLE
Handle network removal gracefully

### DIFF
--- a/tempest-testing-docker/src/main/kotlin/app/cash/tempest/testing/Containers.kt
+++ b/tempest-testing-docker/src/main/kotlin/app/cash/tempest/testing/Containers.kt
@@ -152,7 +152,11 @@ class Composer(private val name: String, private vararg val containers: Containe
       }
     }
 
-    network.stop()
+    try {
+      network.stop()
+    } catch (th: Throwable) {
+      log.error(th) { "could not remove network ${network.id()}" }
+    }
   }
 
   private class LogContainerResultCallback :

--- a/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/Containers.kt
+++ b/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/Containers.kt
@@ -152,7 +152,11 @@ class Composer(private val name: String, private vararg val containers: Containe
             }
         }
 
-        network.stop()
+        try {
+            network.stop()
+        } catch (th: Throwable) {
+            log.error(th) { "could not remove network ${network.id()}" }
+        }
     }
 
     private class LogContainerResultCallback :


### PR DESCRIPTION
We've encountered some test failures where tempest can't remove the Docker network. I'm not sure why this happens, but it shouldn't cause the test to failure. Instead we should just log a message, just like we do when we fail to remove a container.