### PR TITLE
pass consistentReads through overload

### DIFF
--- a/tempest2/src/main/kotlin/app/cash/tempest2/LogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/LogicalDb.kt
@@ -111,7 +111,7 @@ interface LogicalDb : LogicalTable.Factory {
   fun batchLoad(
     keys: Iterable<Any>,
     consistentReads: Boolean
-  ) = batchLoad(keys, consistentReads = false, MAX_BATCH_READ)
+  ) = batchLoad(keys, consistentReads, MAX_BATCH_READ)
 
   fun batchLoad(
     vararg keys: Any,

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -54,10 +54,11 @@ class LogicalDbBatchTest {
     musicTable.playlistInfo.save(playlistInfo)
 
     val loadedItems = musicDb.batchLoad(
-      PlaylistInfo.Key("PLAYLIST_1"),
+      keys = listOf( PlaylistInfo.Key("PLAYLIST_1"),
       AlbumTrack.Key("ALBUM_1", track_number = 1),
       AlbumTrack.Key("ALBUM_1", track_number = 2),
-      AlbumTrack.Key("ALBUM_1", track_number = 3)
+      AlbumTrack.Key("ALBUM_1", track_number = 3)),
+      consistentReads = true
     )
     assertThat(loadedItems.getItems<AlbumTrack>()).containsAll(albumTracks)
     assertThat(loadedItems.getItems<PlaylistInfo>()).containsExactly(playlistInfo)

--- a/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/LogicalDbBatchTest.kt
@@ -54,10 +54,12 @@ class LogicalDbBatchTest {
     musicTable.playlistInfo.save(playlistInfo)
 
     val loadedItems = musicDb.batchLoad(
-      keys = listOf( PlaylistInfo.Key("PLAYLIST_1"),
-      AlbumTrack.Key("ALBUM_1", track_number = 1),
-      AlbumTrack.Key("ALBUM_1", track_number = 2),
-      AlbumTrack.Key("ALBUM_1", track_number = 3)),
+      keys = listOf(
+        PlaylistInfo.Key("PLAYLIST_1"),
+        AlbumTrack.Key("ALBUM_1", track_number = 1),
+        AlbumTrack.Key("ALBUM_1", track_number = 2),
+        AlbumTrack.Key("ALBUM_1", track_number = 3)
+      ),
       consistentReads = true
     )
     assertThat(loadedItems.getItems<AlbumTrack>()).containsAll(albumTracks)


### PR DESCRIPTION
Currently this is not respecting the `consistentReads` parameter. This PR fixes that by removing the hard-coded value.