### PR TITLE
Make the aarch64 lib dependency unconditional

### DIFF
--- a/tempest-testing-jvm/build.gradle.kts
+++ b/tempest-testing-jvm/build.gradle.kts
@@ -14,9 +14,8 @@ dependencies {
     implementation(libs.awsDynamodbLocal)
     implementation(libs.kotlinStdLib)
 
-    if (org.apache.tools.ant.taskdefs.condition.Os.isArch("aarch64")) {
-        implementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
-    }
+    // Needed for com.amazonaws:DynamoDBLocal to work on macOS Aarch64 machines
+    implementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
 
     testImplementation(libs.assertj)
     testImplementation(libs.junitApi)

--- a/tempest2-testing-jvm/build.gradle.kts
+++ b/tempest2-testing-jvm/build.gradle.kts
@@ -14,9 +14,8 @@ dependencies {
   implementation(libs.awsDynamodbLocal)
   implementation(libs.kotlinStdLib)
 
-  if (org.apache.tools.ant.taskdefs.condition.Os.isArch("aarch64")) {
-    implementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
-  }
+  // Needed for com.amazonaws:DynamoDBLocal to work on macOS Aarch64 machines
+  implementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
 
   testImplementation(libs.assertj)
   testImplementation(libs.junitApi)


### PR DESCRIPTION
This should allow downstream consumers of tempest to automatically pick up the correct libsqlite version without having to duplicate this dependency into their own builds.