### PR TITLE
Upgrade AWS DynamoDB Local to v2.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
 aws2Dynamodb = { module = "software.amazon.awssdk:dynamodb", version = "2.25.11" }
 aws2DynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version = "2.25.11" }
 awsDynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version = "1.11.960" }
-awsDynamodbLocal = { module = "com.amazonaws:DynamoDBLocal", version = "1.13.5" }
+awsDynamodbLocal = { module = "com.amazonaws:DynamoDBLocal", version = "2.6.0" }
 clikt = { module = "com.github.ajalt:clikt", version = "2.8.0" }
 dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
 dockerCore = { module = "com.github.docker-java:docker-java-core", version = "3.2.13" }

--- a/tempest-testing-jvm/build.gradle.kts
+++ b/tempest-testing-jvm/build.gradle.kts
@@ -14,9 +14,6 @@ dependencies {
     implementation(libs.awsDynamodbLocal)
     implementation(libs.kotlinStdLib)
 
-    // Needed for com.amazonaws:DynamoDBLocal to work on macOS Aarch64 machines
-    implementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
-
     testImplementation(libs.assertj)
     testImplementation(libs.junitApi)
     testImplementation(libs.junitEngine)

--- a/tempest-testing-jvm/src/main/kotlin/app/cash/tempest/testing/JvmDynamoDbServer.kt
+++ b/tempest-testing-jvm/src/main/kotlin/app/cash/tempest/testing/JvmDynamoDbServer.kt
@@ -31,57 +31,11 @@ class JvmDynamoDbServer private constructor(
   private lateinit var server: DynamoDBProxyServer
 
   override fun startUp() {
-    val libraryFile = libsqlite4javaNativeLibrary()
-    System.setProperty("sqlite4java.library.path", libraryFile.parent)
-
     onBeforeStartup()
     server = ServerRunner.createServerFromCommandLineArgs(
-      arrayOf("-inMemory", "-port", port.toString())
+      arrayOf("-inMemory", "-disableTelemetry", "-port", port.toString())
     )
     server.start()
-  }
-
-  private fun libsqlite4javaNativeLibrary(): File {
-    val prefix = libsqlite4javaPrefix()
-    val classpath = System.getProperty("java.class.path")
-    val classpathElements = classpath.split(File.pathSeparator)
-    for (element in classpathElements) {
-      val file = File(element)
-      if (file.name.startsWith(prefix)) {
-        return file
-      }
-    }
-    throw IllegalArgumentException("couldn't find native library for $prefix")
-  }
-
-  /**
-   * Returns the prefix of the sqlite4java native library for the current platform.
-   *
-   * Observed values of os.arch include:
-   *  * x86_64
-   *  * amd64
-   *  * aarch64
-   *
-   * Observed values of os.name include:
-   *  * Linux
-   *  * Mac OS X
-   *
-   * Available native versions of sqlite4java are:
-   *  * libsqlite4java-linux-amd64-1.0.392.so
-   *  * libsqlite4java-linux-i386-1.0.392.so
-   *  * libsqlite4java-osx-1.0.392.dylib
-   *  * sqlite4java-win32-x64-1.0.392.dll
-   *  * sqlite4java-win32-x86-1.0.392.dll
-   */
-  private fun libsqlite4javaPrefix(): String {
-    val osArch = System.getProperty("os.arch")
-    val osName = System.getProperty("os.name")
-
-    return when {
-      osName == "Linux" && osArch == "amd64" -> "libsqlite4java-linux-amd64-"
-      osName == "Mac OS X" && osArch in listOf("x86_64", "aarch64") -> "libsqlite4java-osx-"
-      else -> throw IllegalStateException("unexpected platform: os.name=$osName os.arch=$osArch")
-    }
   }
 
   override fun shutDown() {

--- a/tempest2-testing-jvm/build.gradle.kts
+++ b/tempest2-testing-jvm/build.gradle.kts
@@ -14,9 +14,6 @@ dependencies {
   implementation(libs.awsDynamodbLocal)
   implementation(libs.kotlinStdLib)
 
-  // Needed for com.amazonaws:DynamoDBLocal to work on macOS Aarch64 machines
-  implementation("io.github.ganadist.sqlite4java:libsqlite4java-osx-aarch64:1.0.392")
-
   testImplementation(libs.assertj)
   testImplementation(libs.junitApi)
   testImplementation(libs.junitEngine)

--- a/tempest2-testing-jvm/src/main/kotlin/app/cash/tempest2/testing/JvmDynamoDbServer.kt
+++ b/tempest2-testing-jvm/src/main/kotlin/app/cash/tempest2/testing/JvmDynamoDbServer.kt
@@ -31,57 +31,11 @@ class JvmDynamoDbServer private constructor(
   private lateinit var server: DynamoDBProxyServer
 
   override fun startUp() {
-    val libraryFile = libsqlite4javaNativeLibrary()
-    System.setProperty("sqlite4java.library.path", libraryFile.parent)
-
     onBeforeStartup()
     server = ServerRunner.createServerFromCommandLineArgs(
-      arrayOf("-inMemory", "-port", port.toString())
+      arrayOf("-inMemory", "-disableTelemetry", "-port", port.toString())
     )
     server.start()
-  }
-
-  private fun libsqlite4javaNativeLibrary(): File {
-    val prefix = libsqlite4javaPrefix()
-    val classpath = System.getProperty("java.class.path")
-    val classpathElements = classpath.split(File.pathSeparator)
-    for (element in classpathElements) {
-      val file = File(element)
-      if (file.name.startsWith(prefix)) {
-        return file
-      }
-    }
-    throw IllegalArgumentException("couldn't find native library for $prefix")
-  }
-
-  /**
-   * Returns the prefix of the sqlite4java native library for the current platform.
-   *
-   * Observed values of os.arch include:
-   *  * x86_64
-   *  * amd64
-   *  * aarch64
-   *
-   * Observed values of os.name include:
-   *  * Linux
-   *  * Mac OS X
-   *
-   * Available native versions of sqlite4java are:
-   *  * libsqlite4java-linux-amd64-1.0.392.so
-   *  * libsqlite4java-linux-i386-1.0.392.so
-   *  * libsqlite4java-osx-1.0.392.dylib
-   *  * sqlite4java-win32-x64-1.0.392.dll
-   *  * sqlite4java-win32-x86-1.0.392.dll
-   */
-  private fun libsqlite4javaPrefix(): String {
-    val osArch = System.getProperty("os.arch")
-    val osName = System.getProperty("os.name")
-
-    return when {
-      osName == "Linux" && osArch == "amd64" -> "libsqlite4java-linux-amd64-"
-      osName == "Mac OS X" && osArch in listOf("x86_64", "aarch64") -> "libsqlite4java-osx-"
-      else -> throw IllegalStateException("unexpected platform: os.name=$osName os.arch=$osArch")
-    }
   }
 
   override fun shutDown() {


### PR DESCRIPTION
This adds support for linux/arm64 and removes the use of the unmaintained sqlite4java