### PR TITLE
Downgrade AWS DynamoDB Local to v2.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
 aws2Dynamodb = { module = "software.amazon.awssdk:dynamodb", version = "2.25.11" }
 aws2DynamodbEnhanced = { module = "software.amazon.awssdk:dynamodb-enhanced", version = "2.25.11" }
 awsDynamodb = { module = "com.amazonaws:aws-java-sdk-dynamodb", version = "1.11.960" }
-awsDynamodbLocal = { module = "com.amazonaws:DynamoDBLocal", version = "2.6.0" }
+awsDynamodbLocal = { module = "com.amazonaws:DynamoDBLocal", version = "2.2.0" }
 clikt = { module = "com.github.ajalt:clikt", version = "2.8.0" }
 dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
 dockerCore = { module = "com.github.docker-java:docker-java-core", version = "3.2.13" }


### PR DESCRIPTION
We need to use a slightly older version because we still depend on Jetty 11 in Misk