### PR TITLE
Post-process the grade module metadata to use the shadow jar deps

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ buildscript {
 
   dependencies {
     classpath(libs.dokkaGradlePlugin)
+    classpath(libs.json)
     classpath(libs.junitGradlePlugin)
     classpath(libs.kotlinGradlePlugin)
     classpath(libs.mavenPublishGradlePlugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ jacksonDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datat
 jettyAlpnClient = { module = "org.eclipse.jetty:jetty-alpn-client", version.ref = "jetty" } # for DynamoDBLocal
 jettyClient = { module = "org.eclipse.jetty:jetty-client", version.ref = "jetty" } # for DynamoDBLocal
 jettyServer = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" } # for DynamoDBLocal
+json = { module = "org.json:json", version = "20250107" }
 junit4Api = { module = "junit:junit", version = "4.13.2" }
 junitApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.8.2" }
 junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.11.4" }


### PR DESCRIPTION
By default, the gradle module metadata points at the unshaded jar and dependencies. Modify the resulting JSON to instead use the dependencies from the shadow jar for the `runtimeElements` variant

Note that while gradle has an API for modifying variants (i.e. `AdhocComponentWithVariants`), it does not provide an ergonomic means for modifying the dependencies, so use post-processing similar to what we already do for the POM file