### PR TITLE
Switch from org.jsom to jackson to preserve property ordering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ buildscript {
 
   dependencies {
     classpath(libs.dokkaGradlePlugin)
-    classpath(libs.json)
+    classpath(libs.jacksonDatabind)
     classpath(libs.junitGradlePlugin)
     classpath(libs.kotlinGradlePlugin)
     classpath(libs.mavenPublishGradlePlugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,6 @@ jacksonDatatypeJsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datat
 jettyAlpnClient = { module = "org.eclipse.jetty:jetty-alpn-client", version.ref = "jetty" } # for DynamoDBLocal
 jettyClient = { module = "org.eclipse.jetty:jetty-client", version.ref = "jetty" } # for DynamoDBLocal
 jettyServer = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" } # for DynamoDBLocal
-json = { module = "org.json:json", version = "20250107" }
 junit4Api = { module = "junit:junit", version = "4.13.2" }
 junitApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.8.2" }
 junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version = "5.11.4" }


### PR DESCRIPTION
Gradle wants `formatVersion` to come first, so switch to a json parser does the right thing