### PR TITLE
chore: simplify shadowJar publishing.

### DIFF
--- a/tempest-testing-jvm/build.gradle.kts
+++ b/tempest-testing-jvm/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 dependencies {
   api(project(":tempest-testing"))
   implementation(project(":tempest-testing-internal"))
-  implementation(project(path = ":tempest-dynamodb-local", configuration = "shadow"))
+  implementation(project(":tempest-dynamodb-local"))
   implementation(libs.kotlinStdLib)
 
   testImplementation(libs.assertj)

--- a/tempest2-testing-jvm/build.gradle.kts
+++ b/tempest2-testing-jvm/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 dependencies {
   api(project(":tempest2-testing"))
   implementation(project(":tempest2-testing-internal"))
-  implementation(project(path = ":tempest-dynamodb-local", configuration = "shadow"))
+  implementation(project(":tempest-dynamodb-local"))
   implementation(libs.kotlinStdLib)
 
   testImplementation(libs.assertj)


### PR DESCRIPTION
https://cash.slack.com/archives/C01G7QB4ANQ/p1746050279119679

Relates to these PRs:
1. https://github.com/cashapp/tempest/pull/225/files
2. https://github.com/cashapp/tempest/pull/226/files
3. https://github.com/cashapp/tempest/pull/228/files

To check this against the current state, one could do the following:
```
# setup tmp dir for comparisons
mkdir -p /tmp/shadowed

# run build A (publishing to maven local)
git checkout main
gradle t-d-l:pTML

# copy output to tmp dir
cp -r ~/.m2/repository/app/cash/tempest/tempest-dynamodb-local/0.0-SNAPSHOT/ /tmp/shadowed/a

# run build B
git checkout <this PR>
gradle t-d-l:pTML

# copy output to tmp dir
cp -r ~/.m2/repository/app/cash/tempest/tempest-dynamodb-local/0.0-SNAPSHOT/ /tmp/shadowed/b

# run diff
diff --brief --recursive /tmp/shadowed/a /tmp/shadowed/b
```
There will be some differences, but they should not result in any semantic difference. 