### PR TITLE
fix: use localhost instead of host.docker.internal for DynamoDB Local test client

### DIFF
--- a/tempest-testing-docker/src/main/kotlin/app/cash/tempest/testing/DockerDynamoDbServer.kt
+++ b/tempest-testing-docker/src/main/kotlin/app/cash/tempest/testing/DockerDynamoDbServer.kt
@@ -70,6 +70,7 @@ class DockerDynamoDbServer private constructor(
   )
 
   object Factory : TestDynamoDbServer.Factory<DockerDynamoDbServer> {
+    override fun hostName(port: Int): String = app.cash.tempest.testing.internal.hostName(port)
     override fun create(port: Int, onBeforeStartup: () -> Unit) = DockerDynamoDbServer(port, onBeforeStartup)
   }
 }

--- a/tempest-testing-internal/src/main/kotlin/app/cash/tempest/testing/internal/DefaultTestDynamoDbClient.kt
+++ b/tempest-testing-internal/src/main/kotlin/app/cash/tempest/testing/internal/DefaultTestDynamoDbClient.kt
@@ -22,14 +22,12 @@ import com.google.common.util.concurrent.AbstractIdleService
 
 class DefaultTestDynamoDbClient(
   override val tables: List<TestTable>,
+  private val hostName: String,
   private val port: Int,
 ) : AbstractIdleService(), TestDynamoDbClient {
-  // Lazy so that hostName is resolved after the DynamoDB Local server is started,
-  // not at construction time when the placeholder ServerSocket is still holding the port.
-  private val hostName by lazy { hostName(port) }
 
-  override val dynamoDb by lazy { buildDynamoDb(hostName, port) }
-  override val dynamoDbStreams by lazy { buildDynamoDbStreams(hostName, port) }
+  override val dynamoDb = buildDynamoDb(hostName, port)
+  override val dynamoDbStreams = buildDynamoDbStreams(hostName, port)
 
   override fun startUp() {
     reset()

--- a/tempest-testing-internal/src/main/kotlin/app/cash/tempest/testing/internal/TestDynamoDbService.kt
+++ b/tempest-testing-internal/src/main/kotlin/app/cash/tempest/testing/internal/TestDynamoDbService.kt
@@ -75,7 +75,7 @@ class TestDynamoDbService private constructor(
     ): TestDynamoDbService {
       val portHolder = port?.let { PortHolder(it) } ?: defaultPortHolder(serverFactory.toString())
       return TestDynamoDbService(
-        DefaultTestDynamoDbClient(tables, portHolder.value),
+        DefaultTestDynamoDbClient(tables, serverFactory.hostName(portHolder.value), portHolder.value),
         serverFactory.create(portHolder.value, portHolder.releasePort)
       )
     }

--- a/tempest-testing-jvm/src/main/kotlin/app/cash/tempest/testing/JvmDynamoDbServer.kt
+++ b/tempest-testing-jvm/src/main/kotlin/app/cash/tempest/testing/JvmDynamoDbServer.kt
@@ -73,6 +73,7 @@ class JvmDynamoDbServer private constructor(
   }
 
   object Factory : TestDynamoDbServer.Factory<JvmDynamoDbServer> {
+    override fun hostName(port: Int) = "localhost"
     override fun create(port: Int, onBeforeStartup: () -> Unit) = JvmDynamoDbServer(port, onBeforeStartup)
   }
 }

--- a/tempest-testing/src/main/kotlin/app/cash/tempest/testing/TestDynamoDbServer.kt
+++ b/tempest-testing/src/main/kotlin/app/cash/tempest/testing/TestDynamoDbServer.kt
@@ -26,6 +26,8 @@ interface TestDynamoDbServer : Service {
   val port: Int
 
   interface Factory<T : TestDynamoDbServer> {
+    /** The hostname the client should use to connect to the server. */
+    fun hostName(port: Int): String
     fun create(port: Int): T = create(port) {}
     fun create(port: Int, onBeforeStartup: () -> Unit): T
   }

--- a/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/DockerDynamoDbServer.kt
+++ b/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/DockerDynamoDbServer.kt
@@ -17,6 +17,7 @@
 package app.cash.tempest2.testing
 
 import app.cash.tempest2.testing.internal.buildDynamoDb
+import app.cash.tempest2.testing.internal.hostName
 import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.Ports
 import com.google.common.util.concurrent.AbstractIdleService
@@ -69,6 +70,7 @@ class DockerDynamoDbServer private constructor(
   )
 
   object Factory : TestDynamoDbServer.Factory<DockerDynamoDbServer> {
+    override fun hostName(port: Int): String = app.cash.tempest2.testing.internal.hostName(port)
     override fun create(port: Int, onBeforeStartup: () -> Unit) = DockerDynamoDbServer(port, onBeforeStartup)
   }
 }

--- a/tempest2-testing-internal/src/main/kotlin/app/cash/tempest2/testing/internal/DefaultTestDynamoDbClient.kt
+++ b/tempest2-testing-internal/src/main/kotlin/app/cash/tempest2/testing/internal/DefaultTestDynamoDbClient.kt
@@ -23,16 +23,14 @@ import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest
 
 class DefaultTestDynamoDbClient(
   override val tables: List<TestTable>,
+  private val hostName: String,
   private val port: Int,
 ) : AbstractIdleService(), TestDynamoDbClient {
-  // Lazy so that hostName is resolved after the DynamoDB Local server is started,
-  // not at construction time when the placeholder ServerSocket is still holding the port.
-  private val hostName by lazy { hostName(port) }
 
-  override val dynamoDb by lazy { buildDynamoDb(hostName, port) }
-  override val asyncDynamoDb by lazy { buildAsyncDynamoDb(hostName, port) }
-  override val dynamoDbStreams by lazy { buildDynamoDbStreams(hostName, port) }
-  override val asyncDynamoDbStreams by lazy { buildAsyncDynamoDbStreams(hostName, port) }
+  override val dynamoDb = buildDynamoDb(hostName, port)
+  override val asyncDynamoDb = buildAsyncDynamoDb(hostName, port)
+  override val dynamoDbStreams = buildDynamoDbStreams(hostName, port)
+  override val asyncDynamoDbStreams = buildAsyncDynamoDbStreams(hostName, port)
 
   override fun startUp() {
     reset()

--- a/tempest2-testing-internal/src/main/kotlin/app/cash/tempest2/testing/internal/TestDynamoDbService.kt
+++ b/tempest2-testing-internal/src/main/kotlin/app/cash/tempest2/testing/internal/TestDynamoDbService.kt
@@ -75,7 +75,7 @@ class TestDynamoDbService(
     ): TestDynamoDbService {
       val portHolder = port?.let { PortHolder(it) } ?: defaultPortHolder(serverFactory.toString())
       return TestDynamoDbService(
-        DefaultTestDynamoDbClient(tables, portHolder.value),
+        DefaultTestDynamoDbClient(tables, serverFactory.hostName(portHolder.value), portHolder.value),
         serverFactory.create(portHolder.value, portHolder.releasePort)
       )
     }

--- a/tempest2-testing-jvm/src/main/kotlin/app/cash/tempest2/testing/JvmDynamoDbServer.kt
+++ b/tempest2-testing-jvm/src/main/kotlin/app/cash/tempest2/testing/JvmDynamoDbServer.kt
@@ -73,6 +73,7 @@ class JvmDynamoDbServer private constructor(
   }
 
   object Factory : TestDynamoDbServer.Factory<JvmDynamoDbServer> {
+    override fun hostName(port: Int) = "localhost"
     override fun create(port: Int, onBeforeStartup: () -> Unit) = JvmDynamoDbServer(port, onBeforeStartup)
   }
 }

--- a/tempest2-testing/src/main/kotlin/app/cash/tempest2/testing/TestDynamoDbServer.kt
+++ b/tempest2-testing/src/main/kotlin/app/cash/tempest2/testing/TestDynamoDbServer.kt
@@ -26,6 +26,8 @@ interface TestDynamoDbServer : Service {
   val port: Int
 
   interface Factory<T : TestDynamoDbServer> {
+    /** The hostname the client should use to connect to the server. */
+    fun hostName(port: Int): String
     fun create(port: Int): T = create(port) {}
     fun create(port: Int, onBeforeStartup: () -> Unit): T
   }


### PR DESCRIPTION
DefaultTestDynamoDbClient used hostName() to auto-detect whether to connect via host.docker.internal or localhost. In environments with Docker installed (including CI), host.docker.internal resolves to the host machine. Since DynamoDB Local binds to 0.0.0.0, the TCP connection check in hostName() always succeeds for host.docker.internal, but DynamoDB Local's Jetty 12 returns HTTP 404 for requests with that Host header, failing the test.

The fix adds a hostName(port) method to TestDynamoDbServer.Factory, so the Factory implementations can more deterministically select the hostname. DockerDynamoDbServer.Factory overrides it with the host.docker.internal auto-detection (needed when the test process itself runs inside Docker). TestDynamoDbService.create() now passes the factory-determined hostname to DefaultTestDynamoDbClient.