### PR TITLE
fix: drain BatchGetItem paginator in async batchLoad to retry UnprocessedKeys

### DIFF
--- a/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
+++ b/tempest2/src/main/kotlin/app/cash/tempest2/internal/DynamoDbLogicalDb.kt
@@ -161,7 +161,7 @@ internal class DynamoDbLogicalDb(
       )
 
       return batchRequests
-        .map { request -> dynamoDbEnhancedClient.batchGetItem(request).limit(1).asFlow() }
+        .map { request -> dynamoDbEnhancedClient.batchGetItem(request).asFlow() }
         .reduce { acc, item -> merge(acc, item) }
         .map { page -> toBatchLoadResponse(requestsByTable, requests, listOf(page)) }
         .asPublisher()

--- a/tempest2/src/test/kotlin/app/cash/tempest2/AsyncLogicalDbBatchTest.kt
+++ b/tempest2/src/test/kotlin/app/cash/tempest2/AsyncLogicalDbBatchTest.kt
@@ -86,6 +86,39 @@ class AsyncLogicalDbBatchTest {
   }
 
   @Test
+  fun `batchLoad more than 16MB`() = runBlockingTest {
+    val twoHundredKbDescription = "a".repeat(200_000)
+
+    // Generate ~20MB of data. Dynamo only supports reading 16MB per batch request, so the SDK
+    // auto-paginator must issue follow-up calls for UnprocessedKeys to return all rows.
+    val albumTracks = (1 until (MAX_BATCH_READ)).map {
+      AlbumTrack(
+        "ALBUM_1",
+        it.toLong(),
+        "track $it",
+        Duration.parse("PT3M28S"),
+        twoHundredKbDescription,
+      )
+    }
+    for (albumTrack in albumTracks) {
+      musicTable.albumTracks.save(albumTrack)
+    }
+    val playlistInfo = PlaylistInfo(
+      playlist_token = "PLAYLIST_1",
+      playlist_name = "WFH Music",
+      playlist_tracks = listOf(AlbumTrack.Key("ALBUM_1", 1))
+    )
+    musicTable.playlistInfo.save(playlistInfo)
+
+    val loadedItems = musicDb.batchLoad(
+      PlaylistInfo.Key("PLAYLIST_1"),
+      *(albumTracks.map { AlbumTrack.Key("ALBUM_1", track_number = it.track_number) }.toTypedArray())
+    )
+    assertThat(loadedItems.getItems<AlbumTrack>()).containsExactlyInAnyOrderElementsOf(albumTracks)
+    assertThat(loadedItems.getItems<PlaylistInfo>()).containsExactly(playlistInfo)
+  }
+
+  @Test
   fun batchLoadMultipleTables() = runBlockingTest {
     val albumTracks = listOf(
       AlbumTrack("ALBUM_1", 1, "dreamin'", Duration.parse("PT3M28S")),


### PR DESCRIPTION
## Summary

`AsyncLogicalDb.batchLoad` (and `batchLoadAsync`) silently drops `UnprocessedKeys` returned by DynamoDB under throttling or partial-result conditions, contradicting the KDoc:

> A single operation can retrieve up to 16 MB of data, which can contain as many as 100 items. BatchGetItem returns a partial result if the response size limit is exceeded, the table's provisioned throughput is exceeded, or an internal processing failure occurs. **If a partial result is returned, this method backs off and retries the `UnprocessedKeys` in the next API call.**

The implementation called `dynamoDbEnhancedClient.batchGetItem(request).limit(1).asFlow()`. `batchGetItem` returns a `BatchGetResultPagePublisher` whose auto-paginator emits one `BatchGetResultPage` per HTTP round-trip and continues issuing follow-up `BatchGetItem` calls as long as the previous response had `UnprocessedKeys`. The `.limit(1)` truncated this to the first page — so any keys returned in `UnprocessedKeys` on that first response were never retried, never decoded, and the caller never found out.

Callers couldn't distinguish "key didn't exist" from "throttled and silently dropped." The sync `LogicalDb.batchLoad` path was already correct (it drains the full paginator iterator) and was independently fixed in #176; the async path was missed.

This PR drops `.limit(1)` and lets the paginator drain naturally. The suspend wrapper in `AsyncLogicalDb.batchLoad` already accumulates across multiple `ItemSet` emissions via `reduce { acc, item -> ItemSet(acc.getAllItems() + item.getAllItems()) }`, so removing `.limit(1)` composes correctly downstream.

### History

The `.limit(1)` originated in #154, which converted `batchLoadAsync` from a single-batch publisher (`batchGetItem(batchRequests.first()).limit(1)`) into chunked flows. The `.limit(1)` was carried forward from the original single-batch shape without re-evaluating against the SDK's paginator semantics.

## Test plan

- [x] Added `batchLoad more than 16MB` test in `AsyncLogicalDbBatchTest`, mirroring the existing sync test in `LogicalDbBatchTest`. Generates ~20MB with 200KB descriptions to force the SDK paginator to issue follow-up `BatchGetItem` calls for `UnprocessedKeys`.
- [x] Verified the new test fails on `main` (with `.limit(1)` in place) and passes with the fix.
- [x] Full `:tempest2:test` suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
