### PR TITLE
fix: Add a mechanism to override auth alongside the image override

### DIFF
--- a/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/Containers.kt
+++ b/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/Containers.kt
@@ -8,6 +8,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd
 import com.github.dockerjava.api.command.PullImageResultCallback
 import com.github.dockerjava.api.command.WaitContainerResultCallback
 import com.github.dockerjava.api.exception.NotFoundException
+import com.github.dockerjava.api.model.AuthConfig
 import com.github.dockerjava.api.model.Frame
 import com.github.dockerjava.core.DefaultDockerClientConfig
 import com.github.dockerjava.core.DockerClientImpl
@@ -30,9 +31,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 data class Container(
     val createCmd: CreateContainerCmd.() -> Unit,
-    val beforeStartHook: (docker: DockerClient, id: String) -> Unit
+    val beforeStartHook: (docker: DockerClient, id: String) -> Unit,
+    val authConfig: AuthConfig?
 ) {
-    constructor(createCmd: CreateContainerCmd.() -> Unit) : this(createCmd, { _, _ -> })
+    constructor(createCmd: CreateContainerCmd.() -> Unit) : this(createCmd, { _, _ -> }, null)
+    constructor(createCmd: CreateContainerCmd.() -> Unit, beforeStartHook: (docker: DockerClient, id: String) -> Unit) : this(createCmd, beforeStartHook, null)
 }
 
 /**
@@ -107,6 +110,11 @@ class Composer(private val name: String, private vararg val containers: Containe
                 val imageParts = image.split(":")
                 docker.pullImageCmd(imageParts[0])
                     .withTag(imageParts.getOrElse(1) { "latest" })
+                    .also { pullCmd ->
+                        container.authConfig?.let { authConfig ->
+                            pullCmd.withAuthConfig(authConfig)
+                        }
+                    }
                     .exec(PullImageResultCallback()).awaitCompletion()
             }
 

--- a/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/DockerDynamoDbServer.kt
+++ b/tempest2-testing-docker/src/main/kotlin/app/cash/tempest2/testing/DockerDynamoDbServer.kt
@@ -18,6 +18,7 @@ package app.cash.tempest2.testing
 
 import app.cash.tempest2.testing.internal.buildDynamoDb
 import app.cash.tempest2.testing.internal.hostName
+import com.github.dockerjava.api.model.AuthConfig
 import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.Ports
 import com.google.common.util.concurrent.AbstractIdleService
@@ -27,7 +28,8 @@ import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
 class DockerDynamoDbServer private constructor(
   override val port: Int,
   private val onBeforeStartup: () -> Unit,
-  imageResolver: (String) -> String
+  imageResolver: (String) -> String,
+  authProvider: (() -> AuthConfig)?
 ) : AbstractIdleService(), TestDynamoDbServer {
 
   override val id = "tempest2-docker-dynamodb-local-$port"
@@ -60,17 +62,20 @@ class DockerDynamoDbServer private constructor(
 
   private val composer = Composer(
     "e-$id",
-    Container {
-      // DynamoDB Local listens on port 8000 by default.
-      val exposedClientPort = ExposedPort.tcp(8000)
-      val portBindings = Ports()
-      portBindings.bind(exposedClientPort, Ports.Binding.bindPort(port))
-      withImage(resolvedImage)
-        .withName(id)
-        .withExposedPorts(exposedClientPort)
-        .withCmd("-jar", "DynamoDBLocal.jar", "-sharedDb", "-disableTelemetry")
-        .withPortBindings(portBindings)
-    }
+    Container(createCmd = {
+        // DynamoDB Local listens on port 8000 by default.
+        val exposedClientPort = ExposedPort.tcp(8000)
+        val portBindings = Ports()
+        portBindings.bind(exposedClientPort, Ports.Binding.bindPort(port))
+        withImage(resolvedImage)
+          .withName(id)
+          .withExposedPorts(exposedClientPort)
+          .withCmd("-jar", "DynamoDBLocal.jar", "-sharedDb", "-disableTelemetry")
+          .withPortBindings(portBindings)
+      },
+      beforeStartHook = { _, _ -> },
+      authConfig = authProvider?.let { it() },
+    )
   )
 
   object Factory : TestDynamoDbServer.Factory<DockerDynamoDbServer> {
@@ -84,10 +89,11 @@ class DockerDynamoDbServer private constructor(
      * ```
      */
     var imageResolver: (String) -> String = { it }
+    var authProvider: (() -> AuthConfig)? = null
 
     override fun hostName(port: Int): String = app.cash.tempest2.testing.internal.hostName(port)
     override fun create(port: Int, onBeforeStartup: () -> Unit) =
-      DockerDynamoDbServer(port, onBeforeStartup, imageResolver)
+      DockerDynamoDbServer(port, onBeforeStartup, imageResolver, authProvider)
   }
 
   companion object {


### PR DESCRIPTION
When overriding the image to set up a mirror, the mirror may require different credentials and so we need a mechanism to override the auth credentials too. This is a follow-up to https://github.com/cashapp/tempest/pull/257